### PR TITLE
Fix Hatch test configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 ]
 [tool.hatch.envs.test.scripts]
 run = "pytest {args:tests}"
+cov = "pytest --cov=src/meta_agent --cov-branch {args:tests}"
 
 # Static type env – mypy is preinstalled in the image :contentReference[oaicite:2]{index=2}
 [tool.hatch.envs.types]


### PR DESCRIPTION
## Summary
- add a `cov` script under `[tool.hatch.envs.test.scripts]`

## Testing
- `hatch -e test run cov -v --cov-report=term-missing` *(fails: Could not find a version that satisfies the requirement pytest-cov)*