### PR TITLE
Implement ToolDesignerAgent core

### DIFF
--- a/src/meta_agent/agents/tool_designer_agent.py
+++ b/src/meta_agent/agents/tool_designer_agent.py
@@ -80,6 +80,7 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
             loader=jinja2.FileSystemLoader(self.template_dir),
             autoescape=jinja2.select_autoescape(['html', 'xml'])
         )
+        self.jinja_env.globals['map_type'] = lambda t: TYPE_MAP.get(t.lower(), t)
         logger.info(f"Jinja environment loaded from: {self.template_dir}")
         
         # Always attempt to initialize LLM components.

--- a/src/meta_agent/cli/main.py
+++ b/src/meta_agent/cli/main.py
@@ -90,7 +90,14 @@ async def generate(spec_file: Path | None, spec_text: str | None):
             # TODO: Configure these properly, maybe via CLI options or config files
             planning_engine = PlanningEngine()
             sub_agent_manager = SubAgentManager()
-            orchestrator = MetaAgentOrchestrator(planning_engine, sub_agent_manager)
+            tool_registry = ToolRegistry()
+            tool_designer_agent = ToolDesignerAgent()
+            orchestrator = MetaAgentOrchestrator(
+                planning_engine=planning_engine,
+                sub_agent_manager=sub_agent_manager,
+                tool_registry=tool_registry,
+                tool_designer_agent=tool_designer_agent,
+            )
 
             # Run the orchestration
             click.echo("\nStarting agent generation orchestration...")

--- a/src/meta_agent/generators/tool_code_generator.py
+++ b/src/meta_agent/generators/tool_code_generator.py
@@ -2,6 +2,7 @@ import ast
 import logging
 import re
 from typing import Any, Dict
+from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 from meta_agent.parsers.tool_spec_parser import ToolSpecification
 
@@ -39,17 +40,19 @@ class ToolCodeGenerator:
     def __init__(self, specification: ToolSpecification):
         self.specification = specification
         if not ToolCodeGenerator._env:
+            template_dir = Path(__file__).parent.parent / "templates"
             ToolCodeGenerator._env = Environment(
-                loader=FileSystemLoader(searchpath="."),
-                trim_blocks=True, lstrip_blocks=True
+                loader=FileSystemLoader(searchpath=str(template_dir)),
+                trim_blocks=True,
+                lstrip_blocks=True,
             )
             ToolCodeGenerator._env.globals['map_type'] = map_type
         if not ToolCodeGenerator._template:
-            ToolCodeGenerator._template = ToolCodeGenerator._env.get_template("tool_template.j2")
+            ToolCodeGenerator._template = ToolCodeGenerator._env.get_template("tool_template.py.j2")
 
     def generate(self) -> str:
         try:
-            generated_code = ToolCodeGenerator._template.render(tool=self.specification)
+            generated_code = ToolCodeGenerator._template.render(spec=self.specification)
             try:
                 ast.parse(generated_code)
             except SyntaxError as se:

--- a/src/meta_agent/services/llm_service.py
+++ b/src/meta_agent/services/llm_service.py
@@ -178,17 +178,18 @@ class LLMService:
         try:
             if isinstance(response.get("output"), list):
                 for item in response["output"]:
-                    if isinstance(item, dict) and item.get("type") == "message":
-                        if (
-                            isinstance(item.get("content"), list) and
-                            len(item["content"]) > 0 and
-                            isinstance(item["content"][0], dict) and
-                            item["content"][0].get("type") == "output_text" and
-                            isinstance(item["content"][0].get("text"), str)
-                        ):
-                            content_str = item["content"][0]["text"]
-                            break # Found the main message content
-            
+                    if isinstance(item, dict):
+                        content = None
+                        if isinstance(item.get("content"), list) and item["content"]:
+                            first = item["content"][0]
+                            if isinstance(first, dict) and isinstance(first.get("text"), str):
+                                content = first["text"]
+                        elif isinstance(item.get("text"), str):
+                            content = item["text"]
+                        if content:
+                            content_str = content
+                            break
+
             if not content_str:
                 self.logger.error(
                     "Failed to extract content string from 'responses' endpoint. Expected 'output' list with a 'message' type item containing 'output_text'."

--- a/src/meta_agent/templates/tool_template.py.j2
+++ b/src/meta_agent/templates/tool_template.py.j2
@@ -6,18 +6,18 @@ logger = logging.getLogger(__name__)
 # {{ spec.purpose }}
 def {{ spec.name }}(
     {%- for param in spec.input_parameters %}
-    {{ param.name }}: {{ param.type_ }}{% if not param.required %} = None{% endif %}{% if not loop.last %},{% endif %}
+    {{ param.name }}: {{ map_type(param.type_) }}{% if not param.required %} = None{% endif %}{% if not loop.last %},{% endif %}
     {%- endfor %}
-) -> {{ spec.output_format }}:
+) -> {{ map_type(spec.output_format) }}:
     """{{ spec.purpose }}
 
     Args:
     {%- for param in spec.input_parameters %}
-        {{ param.name }} ({{ param.type_ }}{% if not param.required %}, optional{% endif %}): {{ param.description or 'No description provided.' }}
+        {{ param.name }}: {{ param.description or 'No description provided.' }} {% if param.required %}(Required){% else %}(Optional){% endif %}
     {%- endfor %}
 
     Returns:
-        {{ spec.output_format }}: Description of the expected output.
+        {{ map_type(spec.output_format) }}: {{ spec.output_format }}
     """
     logger.info(f"Running tool: {{ spec.name }}")
     # --- Tool Implementation Start ---


### PR DESCRIPTION
## Summary
- implement ToolDesignerAgent jinja environment utility
- load templates from package data when generating tools
- produce cleaner tool templates using `map_type`
- improve registry loading by handling factories and class names
- parse simpler structures in LLM service

## Testing
- `pytest tests/agents/test_tool_designer_agent.py -q`
- `pytest tests/generators/test_tool_code_generator.py -q`
- `pytest tests/unit/test_llm_service.py -q`
