### PR TITLE
chore: migrate to uv and remove Hatch CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,4 @@ node_modules/
 
 # Task files
 tasks.json
-tasks/ hatch.lock
-hatch.lock
-hatch.lock
+tasks/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 A task management system for AI-driven development with Claude, designed to work seamlessly with Cursor AI.
 
+Use **uv** for everything (`uv venv`, `uv pip install -r uv.lock`). We no longer use Hatch; hatchling only builds wheels.
+
 ## Requirements
 
 - Node.js 14.0.0 or higher

--- a/docs/openai_agents_sdk_docs.md
+++ b/docs/openai_agents_sdk_docs.md
@@ -18,11 +18,11 @@ that can be composed into arbitrarily complex workflows.
 ```bash
 # Create an isolated project
 mkdir my_project && cd my_project
-python -m venv .venv
+uv venv
 source .venv/bin/activate
 
 # Install the SDK
-pip install openai-agents           # or: uv add openai-agents
+uv pip install openai-agents           # or: uv add openai-agents
 
 # Configure credentials
 export OPENAI_API_KEY="sk‑…"        # required for LLM calls & tracing

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts = -p pytest_asyncio -p no:anyio
 asyncio_default_fixture_loop_scope = function
-norecursedirs = src/.tool_designer temp_sandbox_test_code .git .hatch .tox venv* *.egg* build dist
+norecursedirs = src/.tool_designer temp_sandbox_test_code .git .tox venv* *.egg* build dist
 markers =
     asyncio: mark a test as asyncio.
 log_cli = true

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install project + test extras into the system interpreter
-python -m pip install -e ".[test]"
+# Create a virtual environment and install dependencies
+uv venv
+uv pip install -r uv.lock --extra test
+

--- a/tasks/task_001.txt
+++ b/tasks/task_001.txt
@@ -42,7 +42,7 @@ Implementation steps:
 
 Testing approach:
 - Verify the project structure is correctly set up
-- Ensure package can be installed in development mode with `pip install -e .`
+ - Ensure package can be installed in development mode with `uv pip install -e .`
 - Confirm Git repository is properly initialized
 
 ## 2. Implement SpecSchema Data Model [done]

--- a/tests/integration/test_llm_service_integration.py
+++ b/tests/integration/test_llm_service_integration.py
@@ -31,4 +31,4 @@ async def test_llm_service_live_api_call():
         pytest.fail(f"LLMService.generate_code failed with an unexpected exception: {e}")
 
 # To run this test specifically (ensure .env or OPENAI_API_KEY is set):
-# hatch run test tests/integration/test_llm_service_integration.py
+# uv pip install -r uv.lock --extra test && pytest tests/integration/test_llm_service_integration.py

--- a/uv-test.lock
+++ b/uv-test.lock
@@ -1,0 +1,1 @@
+# Placeholder lock file. Regenerate with 'uv pip compile pyproject.toml --extra test -o uv-test.lock'.

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1 @@
+# Placeholder lock file. Regenerate with 'uv pip compile pyproject.toml -o uv.lock'.


### PR DESCRIPTION
## Summary
- remove hatch references
- document uv usage in README
- add placeholder uv.lock files
- update setup script to install with uv
- swap example docs and tests to mention uv

## Testing
- `pytest -v --cov=src/meta_agent tests` *(fails: ValueError & TypeError in several tests)*