### PR TITLE
fix: address failing tests

### DIFF
--- a/src/meta_agent/orchestrator.py
+++ b/src/meta_agent/orchestrator.py
@@ -9,11 +9,12 @@ from typing import Any, Dict, List, Optional
 import hashlib
 import json
 import time
-from packaging.version import parse as parse_version # Added for version bumping
+from packaging.version import parse as parse_version  # Added for version bumping
 
 from .planning_engine import PlanningEngine
 from .sub_agent_manager import SubAgentManager
 from .registry import ToolRegistry
+
 # Placeholder for ToolDesignerAgent - adjust path as needed
 from .tool_designer import ToolDesignerAgent, GeneratedTool
 
@@ -26,12 +27,13 @@ class MetaAgentOrchestrator:
     using specialized sub-agents.
     """
 
-    def __init__(self,
-                 planning_engine: PlanningEngine,
-                 sub_agent_manager: SubAgentManager,
-                 tool_registry: Optional[ToolRegistry] = None,
-                 tool_designer_agent: Optional[ToolDesignerAgent] = None
-                 ):
+    def __init__(
+        self,
+        planning_engine: PlanningEngine,
+        sub_agent_manager: SubAgentManager,
+        tool_registry: Optional[ToolRegistry] = None,
+        tool_designer_agent: Optional[ToolDesignerAgent] = None,
+    ):
         """Initializes the Orchestrator with necessary components."""
         # self.agent = agent # Removed main agent dependency
         self.planning_engine = planning_engine
@@ -39,7 +41,7 @@ class MetaAgentOrchestrator:
         # Allow constructing with defaults for easier testing
         self.tool_registry = tool_registry or ToolRegistry()
         self.tool_designer_agent = tool_designer_agent or ToolDesignerAgent()
-        self.spec_fingerprint_cache: Dict[str, str] = {} # Added cache
+        self.spec_fingerprint_cache: Dict[str, str] = {}  # Added cache
         # Metrics Counters
         self.tool_cached_hit_total = 0
         self.tool_generated_total = 0
@@ -47,18 +49,24 @@ class MetaAgentOrchestrator:
         self.tool_refined_total = 0
         self.tool_refinement_failed_total = 0
 
-        logger.info("MetaAgentOrchestrator initialized with PlanningEngine, SubAgentManager, ToolRegistry, and ToolDesignerAgent.")
+        logger.info(
+            "MetaAgentOrchestrator initialized with PlanningEngine, SubAgentManager, ToolRegistry, and ToolDesignerAgent."
+        )
 
     async def run(self, specification: Dict[str, Any]) -> Any:
         """
         Entry point for orchestrating agent creation and execution.
         """
-        logger.info(f"Starting orchestration for specification: {specification.get('name', 'Unnamed')}")
+        logger.info(
+            f"Starting orchestration for specification: {specification.get('name', 'Unnamed')}"
+        )
         try:
             # 1. Decompose the specification into tasks
             # TODO: Enhance decompose_spec to return tasks with specific inputs/details
             decomposed_tasks = self.decompose_spec(specification)
-            logger.info(f"Specification decomposed into {len(decomposed_tasks.get('subtasks', []))} tasks.")
+            logger.info(
+                f"Specification decomposed into {len(decomposed_tasks.get('subtasks', []))} tasks."
+            )
 
             # 2. Analyze tasks and create an execution plan
             execution_plan = self.planning_engine.analyze_tasks(decomposed_tasks)
@@ -68,7 +76,7 @@ class MetaAgentOrchestrator:
             execution_results = await self._execute_plan(execution_plan)
 
             logger.info("Orchestration completed successfully.")
-            return execution_results # Return the dictionary of results
+            return execution_results  # Return the dictionary of results
         except Exception as e:
             logger.error(f"Orchestration failed: {e}", exc_info=True)
             # Include partial results if available
@@ -80,7 +88,7 @@ class MetaAgentOrchestrator:
         try:
             normalized_spec_json = json.dumps(spec, sort_keys=True, ensure_ascii=False)
             hasher = hashlib.sha256()
-            hasher.update(normalized_spec_json.encode('utf-8'))
+            hasher.update(normalized_spec_json.encode("utf-8"))
             # Return the first 16 characters of the hex digest as per guidance
             return hasher.hexdigest()[:16]
         except (TypeError, ValueError) as e:
@@ -88,36 +96,60 @@ class MetaAgentOrchestrator:
             # Return a default value or raise an exception? Returning empty for now.
             return ""
 
-    async def design_and_register_tool(self, tool_spec: Dict[str, Any], version: str = "0.1.0") -> Optional[str]:
+    async def design_and_register_tool(
+        self, tool_spec: Dict[str, Any], version: str = "0.1.0"
+    ) -> Optional[str]:
         """Designs a new tool using ToolDesignerAgent and registers it, using a cache."""
         start_time_full = time.monotonic()
         tool_name = tool_spec.get("name", "Unnamed tool")
         log_extra_base = {"tool_name": tool_name, "version": version}
-        logger.info(f"Request received to design tool", extra={**log_extra_base, "event": "design_request"})
+        logger.info(
+            f"Request received to design tool",
+            extra={**log_extra_base, "event": "design_request"},
+        )
 
         # 1. Calculate fingerprint and check cache
         fingerprint = self._calculate_spec_fingerprint(tool_spec)
         if not fingerprint:
             duration_ms = (time.monotonic() - start_time_full) * 1000
             logger.error(
-                f"Could not calculate fingerprint. Skipping design.", 
-                extra={**log_extra_base, "event": "design_error", "error": "fingerprint_calculation", "duration_ms": duration_ms, "success": False}
+                f"Could not calculate fingerprint. Skipping design.",
+                extra={
+                    **log_extra_base,
+                    "event": "design_error",
+                    "error": "fingerprint_calculation",
+                    "duration_ms": duration_ms,
+                    "success": False,
+                },
             )
             self.tool_generation_failed_total += 1
             return None
-        
+
         if fingerprint in self.spec_fingerprint_cache:
             cached_module_path = self.spec_fingerprint_cache[fingerprint]
             duration_ms = (time.monotonic() - start_time_full) * 1000
             self.tool_cached_hit_total += 1
             logger.info(
-                f"Cache hit for fingerprint '{fingerprint}'. Reusing registered tool: {cached_module_path}", 
-                extra={**log_extra_base, "event": "design_cache_hit", "fingerprint": fingerprint, "duration_ms": duration_ms, "success": True}
+                f"Cache hit for fingerprint '{fingerprint}'. Reusing registered tool: {cached_module_path}",
+                extra={
+                    **log_extra_base,
+                    "event": "design_cache_hit",
+                    "fingerprint": fingerprint,
+                    "duration_ms": duration_ms,
+                    "success": True,
+                },
             )
             # Optional: Verify the tool still exists in the registry? For now, assume cache is valid.
             return cached_module_path
-        
-        logger.info(f"Cache miss for fingerprint '{fingerprint}'. Proceeding with design.", extra={**log_extra_base, "event": "design_cache_miss", "fingerprint": fingerprint})
+
+        logger.info(
+            f"Cache miss for fingerprint '{fingerprint}'. Proceeding with design.",
+            extra={
+                **log_extra_base,
+                "event": "design_cache_miss",
+                "fingerprint": fingerprint,
+            },
+        )
 
         # 2. Design the tool (cache miss path)
         try:
@@ -130,7 +162,14 @@ class MetaAgentOrchestrator:
                 self.tool_generation_failed_total += 1
                 logger.error(
                     "Tool design or registration failed.",
-                    extra={**log_extra_base, "event": "design_error", "error": "designer_returned_none", "design_duration_ms": design_duration_ms, "duration_ms": duration_ms, "success": False}
+                    extra={
+                        **log_extra_base,
+                        "event": "design_error",
+                        "error": "designer_returned_none",
+                        "design_duration_ms": design_duration_ms,
+                        "duration_ms": duration_ms,
+                        "success": False,
+                    },
                 )
                 return None
 
@@ -143,14 +182,29 @@ class MetaAgentOrchestrator:
                 self.spec_fingerprint_cache[fingerprint] = module_path
                 logger.info(
                     f"Tool designed and registered successfully at {module_path}. Stored in cache.",
-                    extra={**log_extra_base, "event": "design_success", "fingerprint": fingerprint, "module_path": module_path, "design_duration_ms": design_duration_ms, "duration_ms": duration_ms, "success": True}
+                    extra={
+                        **log_extra_base,
+                        "event": "design_success",
+                        "fingerprint": fingerprint,
+                        "module_path": module_path,
+                        "design_duration_ms": design_duration_ms,
+                        "duration_ms": duration_ms,
+                        "success": True,
+                    },
                 )
                 return module_path
             else:
                 self.tool_generation_failed_total += 1
                 logger.error(
                     "Tool design or registration failed.",
-                    extra={**log_extra_base, "event": "design_error", "error": "registration_failed", "design_duration_ms": design_duration_ms, "duration_ms": duration_ms, "success": False}
+                    extra={
+                        **log_extra_base,
+                        "event": "design_error",
+                        "error": "registration_failed",
+                        "design_duration_ms": design_duration_ms,
+                        "duration_ms": duration_ms,
+                        "success": False,
+                    },
                 )
                 return None
         except Exception as e:
@@ -159,15 +213,25 @@ class MetaAgentOrchestrator:
             logger.error(
                 f"Exception during tool design or registration: {e}",
                 exc_info=True,
-                extra={**log_extra_base, "event": "design_exception", "duration_ms": duration_ms, "success": False}
+                extra={
+                    **log_extra_base,
+                    "event": "design_exception",
+                    "duration_ms": duration_ms,
+                    "success": False,
+                },
             )
             return None
 
-    async def refine_tool(self, tool_name: str, version: str, feedback_notes: str) -> Optional[str]:
+    async def refine_tool(
+        self, tool_name: str, version: str, feedback_notes: str
+    ) -> Optional[str]:
         """Refines an existing tool based on feedback and registers a new version."""
         start_time_full = time.monotonic()
         log_extra_base = {"tool_name": tool_name, "version": version}
-        logger.info(f"Request received to refine tool based on feedback: {feedback_notes[:50]}...", extra={**log_extra_base, "event": "refine_request"})
+        logger.info(
+            f"Request received to refine tool based on feedback: {feedback_notes[:50]}...",
+            extra={**log_extra_base, "event": "refine_request"},
+        )
 
         # 1. Get original tool metadata (which includes the spec)
         original_metadata = self.tool_registry.get_tool_metadata(tool_name, version)
@@ -175,58 +239,89 @@ class MetaAgentOrchestrator:
             duration_ms = (time.monotonic() - start_time_full) * 1000
             self.tool_refinement_failed_total += 1
             logger.error(
-                f"Could not find metadata to refine.", 
-                extra={**log_extra_base, "event": "refine_error", "error": "metadata_not_found", "duration_ms": duration_ms, "success": False}
+                f"Could not find metadata to refine.",
+                extra={
+                    **log_extra_base,
+                    "event": "refine_error",
+                    "error": "metadata_not_found",
+                    "duration_ms": duration_ms,
+                    "success": False,
+                },
             )
             return None
-        
-        original_spec = original_metadata.get('specification') # Assuming spec is nested like this
+
+        original_spec = original_metadata.get(
+            "specification"
+        )  # Assuming spec is nested like this
         if not original_spec:
             duration_ms = (time.monotonic() - start_time_full) * 1000
             self.tool_refinement_failed_total += 1
             logger.error(
-                f"Original specification not found in metadata.", 
-                extra={**log_extra_base, "event": "refine_error", "error": "spec_not_found", "duration_ms": duration_ms, "success": False}
+                f"Original specification not found in metadata.",
+                extra={
+                    **log_extra_base,
+                    "event": "refine_error",
+                    "error": "spec_not_found",
+                    "duration_ms": duration_ms,
+                    "success": False,
+                },
             )
             return None
-            
+
         # Create a dictionary suitable for the designer, maybe including name/desc?
         # This depends on what refine_design expects. Let's pass the core spec for now.
         # We might need the full GeneratedTool structure eventually.
         design_input_spec = {
-            "name": original_metadata.get("original_name", tool_name), # Use original name if available
+            "name": original_metadata.get(
+                "original_name", tool_name
+            ),  # Use original name if available
             "description": original_metadata.get("description", ""),
-            "specification": original_spec
+            "specification": original_spec,
         }
 
         # 2. Call ToolDesignerAgent to refine the design
         try:
             start_time_refine = time.monotonic()
             # Assumes tool_designer_agent.refine_design exists and is async
-            refined_tool_artefact: Optional[GeneratedTool] = await self.tool_designer_agent.refine_design(design_input_spec, feedback_notes)
+            refined_tool_artefact: Optional[GeneratedTool] = (
+                await self.tool_designer_agent.refine_design(
+                    design_input_spec, feedback_notes
+                )
+            )
             refine_duration_ms = (time.monotonic() - start_time_refine) * 1000
 
             if not refined_tool_artefact:
                 duration_ms = (time.monotonic() - start_time_full) * 1000
                 self.tool_refinement_failed_total += 1
                 logger.error(
-                    f"Tool refinement failed.", 
-                    extra={**log_extra_base, "event": "refine_error", "error": "designer_returned_none", "refine_duration_ms": refine_duration_ms, "duration_ms": duration_ms, "success": False}
+                    f"Tool refinement failed.",
+                    extra={
+                        **log_extra_base,
+                        "event": "refine_error",
+                        "error": "designer_returned_none",
+                        "refine_duration_ms": refine_duration_ms,
+                        "duration_ms": duration_ms,
+                        "success": False,
+                    },
                 )
                 return None
 
             # 3. Determine the new version (major/minor bumps based on IO schema diff)
             try:
                 current_v = parse_version(version)
-                
+
                 # Compare Input/Output Schemas for breaking change detection
                 original_io_spec = {
                     "input": original_spec.get("input_schema", {}),
-                    "output": original_spec.get("output_schema", {})
+                    "output": original_spec.get("output_schema", {}),
                 }
                 refined_io_spec = {
-                    "input": refined_tool_artefact.specification.get("input_schema", {}),
-                    "output": refined_tool_artefact.specification.get("output_schema", {})
+                    "input": refined_tool_artefact.specification.get(
+                        "input_schema", {}
+                    ),
+                    "output": refined_tool_artefact.specification.get(
+                        "output_schema", {}
+                    ),
                 }
 
                 # Normalize by dumping to sorted JSON for comparison
@@ -235,7 +330,9 @@ class MetaAgentOrchestrator:
 
                 if original_io_json != refined_io_json:
                     # Major version bump (breaking change)
-                    logger.info(f"IO schema changed detected during refinement of {tool_name}. Bumping major version.")
+                    logger.info(
+                        f"IO schema changed detected during refinement of {tool_name}. Bumping major version."
+                    )
                     if current_v.major == 0:
                         # Transition from 0.x.y to 1.0.0
                         new_version_str = "1.0.0"
@@ -243,21 +340,30 @@ class MetaAgentOrchestrator:
                         new_version_str = f"{current_v.major + 1}.0.0"
                 else:
                     # Minor version bump (non-breaking change / refinement)
-                    logger.info(f"No IO schema change detected during refinement of {tool_name}. Bumping minor version.")
+                    logger.info(
+                        f"No IO schema change detected during refinement of {tool_name}. Bumping minor version."
+                    )
                     next_minor = current_v.minor + 1
                     new_version_str = f"{current_v.major}.{next_minor}.0"
-            
+
             except Exception as e:
-                logger.error(f"Failed to parse or increment version '{version}': {e}. Using timestamp suffix.")
+                logger.error(
+                    f"Failed to parse or increment version '{version}': {e}. Using timestamp suffix."
+                )
                 # Fallback versioning
-                new_version_str = f"{version}-refined-{int(time.time())}" 
-            
+                new_version_str = f"{version}-refined-{int(time.time())}"
+
             log_extra_refine = {**log_extra_base, "new_version": new_version_str}
-            logger.info(f"Refined tool. Registering new version: {new_version_str}", extra={**log_extra_refine, "event": "refine_register_start"})
+            logger.info(
+                f"Refined tool. Registering new version: {new_version_str}",
+                extra={**log_extra_refine, "event": "refine_register_start"},
+            )
 
             # 4. Register the refined tool as a new version
             start_time_register = time.monotonic()
-            module_path = self.tool_registry.register(refined_tool_artefact, version=new_version_str)
+            module_path = self.tool_registry.register(
+                refined_tool_artefact, version=new_version_str
+            )
             register_duration_ms = (time.monotonic() - start_time_register) * 1000
 
             if module_path:
@@ -265,9 +371,17 @@ class MetaAgentOrchestrator:
                 self.tool_refined_total += 1
                 logger.info(
                     f"Refined tool registered successfully as version '{new_version_str}' at {module_path}",
-                    extra={**log_extra_refine, "event": "refine_success", "module_path": module_path, "refine_duration_ms": refine_duration_ms, "register_duration_ms": register_duration_ms, "duration_ms": duration_ms, "success": True}
+                    extra={
+                        **log_extra_refine,
+                        "event": "refine_success",
+                        "module_path": module_path,
+                        "refine_duration_ms": refine_duration_ms,
+                        "register_duration_ms": register_duration_ms,
+                        "duration_ms": duration_ms,
+                        "success": True,
+                    },
                 )
-                # Note: We are NOT adding this refined version to the spec_fingerprint_cache 
+                # Note: We are NOT adding this refined version to the spec_fingerprint_cache
                 # as the spec itself might not have changed enough to alter the fingerprint,
                 # but the implementation (code) has changed based on feedback.
                 return module_path
@@ -276,16 +390,29 @@ class MetaAgentOrchestrator:
                 self.tool_refinement_failed_total += 1
                 logger.error(
                     f"Registration failed for refined tool version '{new_version_str}'.",
-                    extra={**log_extra_refine, "event": "refine_error", "error": "registry_returned_none", "refine_duration_ms": refine_duration_ms, "register_duration_ms": register_duration_ms, "duration_ms": duration_ms, "success": False}
+                    extra={
+                        **log_extra_refine,
+                        "event": "refine_error",
+                        "error": "registry_returned_none",
+                        "refine_duration_ms": refine_duration_ms,
+                        "register_duration_ms": register_duration_ms,
+                        "duration_ms": duration_ms,
+                        "success": False,
+                    },
                 )
                 return None
         except Exception as e:
             duration_ms = (time.monotonic() - start_time_full) * 1000
             self.tool_refinement_failed_total += 1
             logger.error(
-                f"Exception during tool refinement: {e}", 
-                exc_info=True, 
-                extra={**log_extra_base, "event": "refine_exception", "duration_ms": duration_ms, "success": False}
+                f"Exception during tool refinement: {e}",
+                exc_info=True,
+                extra={
+                    **log_extra_base,
+                    "event": "refine_exception",
+                    "duration_ms": duration_ms,
+                    "success": False,
+                },
             )
             return None
 
@@ -294,23 +421,49 @@ class MetaAgentOrchestrator:
         Stub: Decompose the agent specification into tasks/subspecs.
         Includes a simulated tool requirement.
         """
-        logger.warning("Using stub decompose_spec. Returning dummy tasks including a tool requirement.")
-        
+        logger.warning(
+            "Using stub decompose_spec. Returning dummy tasks including a tool requirement."
+        )
+
         # Sample tool spec for task_2
         sample_tool_spec_for_task2 = {
             "name": "UnitTestHelper",
             "description": "A tool to help generate unit test boilerplate.",
             "specification": {
-                "input_schema": {"type": "object", "properties": {"module_path": {"type": "string", "description": "Path to the module to test"}}},
-                "output_schema": {"type": "string", "description": "Generated test file content"}
-            }
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "module_path": {
+                            "type": "string",
+                            "description": "Path to the module to test",
+                        }
+                    },
+                },
+                "output_schema": {
+                    "type": "string",
+                    "description": "Generated test file content",
+                },
+            },
         }
-        
+
         return {
             "subtasks": [
-                {"id": "task_1", "description": "Generate initial code structure", "agent_type": "coder"}, # Added agent_type example
-                {"id": "task_2", "description": "Write unit tests for the structure", "agent_type": "tester", "requires_tool": sample_tool_spec_for_task2}, # Added tool requirement
-                {"id": "task_3", "description": "Refactor the generated code", "agent_type": "coder"}
+                {
+                    "id": "task_1",
+                    "description": "Generate initial code structure",
+                    "agent_type": "coder",
+                },  # Added agent_type example
+                {
+                    "id": "task_2",
+                    "description": "Write unit tests for the structure",
+                    "agent_type": "tester",
+                    "requires_tool": sample_tool_spec_for_task2,
+                },  # Added tool requirement
+                {
+                    "id": "task_3",
+                    "description": "Refactor the generated code",
+                    "agent_type": "coder",
+                },
             ]
         }
 
@@ -321,7 +474,9 @@ class MetaAgentOrchestrator:
         logger.info("Starting task execution loop...")
         execution_results = {}
         execution_order = execution_plan.get("execution_order", [])
-        task_requirements_map = {req['task_id']: req for req in execution_plan.get("task_requirements", [])}
+        task_requirements_map = {
+            req["task_id"]: req for req in execution_plan.get("task_requirements", [])
+        }
 
         if not execution_order:
             logger.warning("Execution order is empty. No tasks to execute.")
@@ -329,46 +484,71 @@ class MetaAgentOrchestrator:
 
         for task_id in execution_order:
             if task_id not in task_requirements_map:
-                logger.error(f"Task ID {task_id} found in execution_order but not in task_requirements. Skipping.")
-                execution_results[task_id] = {"status": "error", "error": "Missing task requirements"}
+                logger.error(
+                    f"Task ID {task_id} found in execution_order but not in task_requirements. Skipping."
+                )
+                execution_results[task_id] = {
+                    "status": "error",
+                    "error": "Missing task requirements",
+                }
                 continue
 
             task_req = task_requirements_map[task_id]
-            
+
             # *** START: Added Tool Requirement Check ***
             if "requires_tool" in task_req:
                 tool_spec_needed = task_req["requires_tool"]
                 tool_name_needed = tool_spec_needed.get("name", "Unnamed required tool")
-                logger.info(f"Task {task_id} requires tool '{tool_name_needed}'. Checking/designing tool...")
-                
+                logger.info(
+                    f"Task {task_id} requires tool '{tool_name_needed}'. Checking/designing tool..."
+                )
+
                 # Attempt to design and register the tool (handles caching internally)
                 module_path = await self.design_and_register_tool(tool_spec_needed)
-                
+
                 if not module_path:
-                    logger.error(f"Failed to obtain required tool '{tool_name_needed}' for task {task_id}. Skipping task.")
-                    execution_results[task_id] = {"status": "failed", "error": f"Required tool '{tool_name_needed}' could not be designed or registered."}
-                    continue # Skip this task as the required tool is missing
+                    logger.error(
+                        f"Failed to obtain required tool '{tool_name_needed}' for task {task_id}. Skipping task."
+                    )
+                    execution_results[task_id] = {
+                        "status": "failed",
+                        "error": f"Required tool '{tool_name_needed}' could not be designed or registered.",
+                    }
+                    continue  # Skip this task as the required tool is missing
                 else:
-                     logger.info(f"Required tool '{tool_name_needed}' is available at {module_path} for task {task_id}.")
-                     # Optional: Update task_req or notify SubAgentManager about the new tool?
-                     # For now, we just ensure it's registered. The sub-agent might load it via registry.
+                    logger.info(
+                        f"Required tool '{tool_name_needed}' is available at {module_path} for task {task_id}."
+                    )
+                    # Optional: Update task_req or notify SubAgentManager about the new tool?
+                    # For now, we just ensure it's registered. The sub-agent might load it via registry.
             # *** END: Added Tool Requirement Check ***
 
             # Proceed with getting the agent and executing the task
-            sub_agent = self.sub_agent_manager.get_or_create_agent(task_req) 
+            sub_agent = self.sub_agent_manager.get_or_create_agent(task_req)
 
             if sub_agent:
                 logger.info(f"Executing task {task_id} using agent {sub_agent.name}...")
                 try:
-                    sub_agent_output = await sub_agent.run(specification=task_req) # Renamed for clarity
-                    logger.info(f"Task {task_id} completed by {sub_agent.name}.") # Removed .get('status') as it might not exist
-                    execution_results[task_id] = {"output": sub_agent_output, "status": "completed"} # Ensure status is set
+                    sub_agent_output = await sub_agent.run(specification=task_req)
+                    result_status = sub_agent_output.get("status", "unknown")
+                    logger.info(
+                        f"Task {task_id} completed by {sub_agent.name}. Result: {result_status}"
+                    )
+                    execution_results[task_id] = sub_agent_output
                 except Exception as e:
-                    logger.error(f"Error executing task {task_id} with agent {sub_agent.name}: {e}", exc_info=True)
+                    logger.error(
+                        f"Error executing task {task_id} with agent {sub_agent.name}: {e}",
+                        exc_info=True,
+                    )
                     execution_results[task_id] = {"status": "failed", "error": str(e)}
             else:
-                logger.error(f"Could not get or create sub-agent for task {task_id}. Skipping execution.")
-                execution_results[task_id] = {"status": "failed", "error": "Sub-agent creation/retrieval failed"}
+                logger.error(
+                    f"Could not get or create sub-agent for task {task_id}. Skipping execution."
+                )
+                execution_results[task_id] = {
+                    "status": "failed",
+                    "error": "Sub-agent creation/retrieval failed",
+                }
 
         logger.info("Orchestration completed successfully.")
         return execution_results

--- a/src/meta_agent/registry.py
+++ b/src/meta_agent/registry.py
@@ -16,18 +16,22 @@ GENERATED_TOOLS_BASE_DIR_NAME = "generated_tools"
 METADATA_FILE_NAME = "metadata.json"
 TOOL_CODE_FILE_NAME = "tool.py"
 
+
 @dataclass
 class GeneratedTool:
     """Represents a generated tool's source code and metadata."""
+
     name: str
     description: str
     code: str  # The Python code for the tool
     specification: Dict[str, Any] = field(default_factory=dict)
 
+
 class ToolRegistry:
     """
     Manages the registration, loading, and discovery of dynamically generated tools.
     """
+
     def __init__(self, base_dir: Union[str, Path] = "src/meta_agent"):
         self.base_dir = Path(base_dir)
         if not self.base_dir.is_absolute():
@@ -37,7 +41,9 @@ class ToolRegistry:
         self.tools_dir.mkdir(parents=True, exist_ok=True)
         (self.tools_dir / "__init__.py").touch(exist_ok=True)
 
-    def _get_tool_version_dir(self, tool_name_sanitized: str, version_sanitized: str) -> Path:
+    def _get_tool_version_dir(
+        self, tool_name_sanitized: str, version_sanitized: str
+    ) -> Path:
         return self.tools_dir / tool_name_sanitized / version_sanitized
 
     def _get_tool_package_dir(self, tool_name_sanitized: str) -> Path:
@@ -47,9 +53,13 @@ class ToolRegistry:
         tool_name_sanitized = tool.name.replace("-", "_").replace(" ", "_").lower()
         version_sanitized = "v" + version.replace(".", "_")
         tool_package_dir = self._get_tool_package_dir(tool_name_sanitized)
-        tool_version_dir = self._get_tool_version_dir(tool_name_sanitized, version_sanitized)
+        tool_version_dir = self._get_tool_version_dir(
+            tool_name_sanitized, version_sanitized
+        )
         if tool_version_dir.exists():
-            logger.warning(f"Tool '{tool.name}' version '{version}' already exists at {tool_version_dir}. Overwriting.")
+            logger.warning(
+                f"Tool '{tool.name}' version '{version}' already exists at {tool_version_dir}. Overwriting."
+            )
         try:
             # Ensure all parent directories exist and are Python packages
             tool_version_dir.parent.parent.mkdir(parents=True, exist_ok=True)
@@ -58,7 +68,7 @@ class ToolRegistry:
             (tool_version_dir.parent / "__init__.py").touch(exist_ok=True)
             tool_version_dir.mkdir(exist_ok=True)
             (tool_version_dir / "__init__.py").touch(exist_ok=True)
-            
+
             # Create the tool code file
             tool_code_path = tool_version_dir / TOOL_CODE_FILE_NAME
             with open(tool_code_path, "w", encoding="utf-8") as f:
@@ -73,15 +83,19 @@ class ToolRegistry:
                 "sanitized_version": version_sanitized,
                 "description": tool.description,
                 "specification": tool.specification,
-                "module_path": module_import_path
+                "module_path": module_import_path,
             }
             metadata_path = tool_version_dir / METADATA_FILE_NAME
             with open(metadata_path, "w", encoding="utf-8") as f:
                 json.dump(metadata, f, indent=2)
-            logger.info(f"Tool '{tool.name}' version '{version}' registered successfully at {tool_version_dir}")
+            logger.info(
+                f"Tool '{tool.name}' version '{version}' registered successfully at {tool_version_dir}"
+            )
             return module_import_path
         except IOError as e:
-            logger.error(f"Failed to register tool '{tool.name}' version '{version}': {e}")
+            logger.error(
+                f"Failed to register tool '{tool.name}' version '{version}': {e}"
+            )
             if tool_version_dir.exists():
                 shutil.rmtree(tool_version_dir)
             return None
@@ -93,7 +107,11 @@ class ToolRegistry:
         versions = []
         for version_name_dir in tool_package_dir.iterdir():
             metadata_path = version_name_dir / METADATA_FILE_NAME
-            if version_name_dir.is_dir() and (version_name_dir / "__init__.py").exists() and metadata_path.exists():
+            if (
+                version_name_dir.is_dir()
+                and (version_name_dir / "__init__.py").exists()
+                and metadata_path.exists()
+            ):
                 try:
                     with open(metadata_path, "r", encoding="utf-8") as f:
                         metadata = json.load(f)
@@ -112,26 +130,35 @@ class ToolRegistry:
         if version == "latest":
             actual_version_str = self._get_latest_version(tool_name_sanitized)
             if not actual_version_str:
-                logger.error(f"No versions found for tool '{tool_name}'. Cannot load 'latest'.")
+                logger.error(
+                    f"No versions found for tool '{tool_name}'. Cannot load 'latest'."
+                )
                 return None
         else:
             actual_version_str = version
         version_sanitized = "v" + actual_version_str.replace(".", "_")
         metadata = self.get_tool_metadata(tool_name, actual_version_str)
-        tool_code_file = self._get_tool_version_dir(tool_name_sanitized, version_sanitized) / TOOL_CODE_FILE_NAME
+        tool_code_file = (
+            self._get_tool_version_dir(tool_name_sanitized, version_sanitized)
+            / TOOL_CODE_FILE_NAME
+        )
         if not tool_code_file.exists():
-            logger.error(f"Tool code file not found for '{tool_name}' v{actual_version_str} at {tool_code_file}")
+            logger.error(
+                f"Tool code file not found for '{tool_name}' v{actual_version_str} at {tool_code_file}"
+            )
             return None
 
         # Get metadata to get the module path
         metadata = self.get_tool_metadata(tool_name, actual_version_str)
         if not metadata or "module_path" not in metadata:
-            logger.error(f"No metadata found for tool '{tool_name}' version '{actual_version_str}'")
+            logger.error(
+                f"No metadata found for tool '{tool_name}' version '{actual_version_str}'"
+            )
             return None
-            
+
         module_full_path = metadata["module_path"]
 
-        importlib.invalidate_caches() # Ensure import system sees new files
+        importlib.invalidate_caches()  # Ensure import system sees new files
         original_sys_path = sys.path[:]
         path_added_to_sys = False
         try:
@@ -139,7 +166,24 @@ class ToolRegistry:
             if str(self.base_dir) not in sys.path:
                 sys.path.insert(0, str(self.base_dir))
                 path_added_to_sys = True
-                importlib.invalidate_caches() # Ensure import system sees new files after sys.path change
+                importlib.invalidate_caches()  # Ensure import system sees new files after sys.path change
+
+            # Ensure generated_tools namespace covers this base directory
+            pkg_name = GENERATED_TOOLS_BASE_DIR_NAME
+            pkg_path = str(self.tools_dir)
+            if pkg_name in sys.modules:
+                pkg = sys.modules[pkg_name]
+                if hasattr(pkg, "__path__") and pkg_path not in pkg.__path__:
+                    pkg.__path__.append(pkg_path)
+            else:
+                spec = importlib.util.spec_from_file_location(
+                    pkg_name, self.tools_dir / "__init__.py"
+                )
+                pkg = importlib.util.module_from_spec(spec)
+                sys.modules[pkg_name] = pkg
+                pkg.__path__ = [pkg_path]
+                if spec and spec.loader:
+                    spec.loader.exec_module(pkg)
 
             logger.info(f"[DIAGNOSTIC] Attempting to import: {module_full_path}")
             logger.info(f"[DIAGNOSTIC] Current sys.path: {sys.path}")
@@ -149,6 +193,8 @@ class ToolRegistry:
             factory = getattr(tool_module, "get_tool_instance", None)
             if callable(factory):
                 tool_instance = factory()
+                setattr(tool_instance, "get_tool_instance", factory)
+                setattr(tool_instance, "__name__", tool_module.__name__)
                 logger.info(
                     f"Tool '{tool_name}' version '{actual_version_str}' loaded successfully from {module_full_path} via factory"
                 )
@@ -157,8 +203,12 @@ class ToolRegistry:
             # Fallback to a class named after the sanitized tool name or with 'Tool' suffix
             tool_class = getattr(tool_module, tool_name_sanitized, None)
             if not tool_class:
-                camel = "".join(part.capitalize() for part in tool_name_sanitized.split("_"))
-                tool_class = getattr(tool_module, f"{camel}Tool", None) or getattr(tool_module, camel, None)
+                camel = "".join(
+                    part.capitalize() for part in tool_name_sanitized.split("_")
+                )
+                tool_class = getattr(tool_module, f"{camel}Tool", None) or getattr(
+                    tool_module, camel, None
+                )
 
             if tool_class:
                 tool_instance = tool_class()
@@ -172,15 +222,19 @@ class ToolRegistry:
                 )
                 return None
         except ImportError as e:
-            logger.error(f"Failed to import tool '{tool_name}' version '{actual_version_str}' from {module_full_path}: {e}")
+            logger.error(
+                f"Failed to import tool '{tool_name}' version '{actual_version_str}' from {module_full_path}: {e}"
+            )
             return None
         except Exception as e:
-            logger.error(f"An unexpected error occurred while loading tool '{tool_name}' version '{actual_version_str}': {e}")
+            logger.error(
+                f"An unexpected error occurred while loading tool '{tool_name}' version '{actual_version_str}': {e}"
+            )
             return None
         finally:
             if path_added_to_sys:
                 sys.path = original_sys_path
-                importlib.invalidate_caches() # Ensure import system sees new files after sys.path restoration
+                importlib.invalidate_caches()  # Ensure import system sees new files after sys.path restoration
                 # Consider importlib.invalidate_caches() here if needed after sys.path restoration
 
     def list_tools(self) -> List[Dict[str, Any]]:
@@ -191,93 +245,140 @@ class ToolRegistry:
             if tool_name_dir.is_dir() and (tool_name_dir / "__init__.py").exists():
                 tool_name_sanitized = tool_name_dir.name
                 versions_data = []
-                original_tool_name_display = tool_name_sanitized 
+                original_tool_name_display = tool_name_sanitized
                 for version_dir in tool_name_dir.iterdir():
                     metadata_path = version_dir / METADATA_FILE_NAME
-                    if version_dir.is_dir() and (version_dir / "__init__.py").exists() and metadata_path.exists():
+                    if (
+                        version_dir.is_dir()
+                        and (version_dir / "__init__.py").exists()
+                        and metadata_path.exists()
+                    ):
                         try:
                             with open(metadata_path, "r", encoding="utf-8") as f:
                                 metadata = json.load(f)
-                            versions_data.append({
-                                "version": metadata.get("version"),
-                                "sanitized_version": metadata.get("sanitized_version"),
-                                "description": metadata.get("description"),
-                                "module_path": metadata.get("module_path"),
-                                "specification": metadata.get("specification", {}),
-                            })
+                            versions_data.append(
+                                {
+                                    "version": metadata.get("version"),
+                                    "sanitized_version": metadata.get(
+                                        "sanitized_version"
+                                    ),
+                                    "description": metadata.get("description"),
+                                    "module_path": metadata.get("module_path"),
+                                    "specification": metadata.get("specification", {}),
+                                }
+                            )
                             if "original_name" in metadata:
                                 original_tool_name_display = metadata["original_name"]
                         except (IOError, json.JSONDecodeError) as e:
-                            logger.warning(f"Could not read metadata for {version_dir}: {e}")
+                            logger.warning(
+                                f"Could not read metadata for {version_dir}: {e}"
+                            )
                 if versions_data:
-                    versions_data.sort(key=lambda v: parse_version(v["version"]), reverse=True)
-                    available_tools.append({
-                        "name": original_tool_name_display,
-                        "sanitized_name": tool_name_sanitized,
-                        "versions": versions_data,
-                    })
+                    versions_data.sort(
+                        key=lambda v: parse_version(v["version"]), reverse=True
+                    )
+                    available_tools.append(
+                        {
+                            "name": original_tool_name_display,
+                            "sanitized_name": tool_name_sanitized,
+                            "versions": versions_data,
+                        }
+                    )
         return available_tools
 
-    def get_tool_metadata(self, tool_name: str, version: str = "latest") -> Optional[Dict[str, Any]]:
+    def get_tool_metadata(
+        self, tool_name: str, version: str = "latest"
+    ) -> Optional[Dict[str, Any]]:
         tool_name_sanitized = tool_name.replace("-", "_").replace(" ", "_").lower()
         if version == "latest":
             actual_version_str = self._get_latest_version(tool_name_sanitized)
             if not actual_version_str:
-                logger.warning(f"No versions found for tool '{tool_name}'. Cannot get metadata for 'latest'.")
+                logger.warning(
+                    f"No versions found for tool '{tool_name}'. Cannot get metadata for 'latest'."
+                )
                 return None
         else:
             actual_version_str = version
         version_sanitized = "v" + actual_version_str.replace(".", "_")
-        metadata_path = self._get_tool_version_dir(tool_name_sanitized, version_sanitized) / METADATA_FILE_NAME
+        metadata_path = (
+            self._get_tool_version_dir(tool_name_sanitized, version_sanitized)
+            / METADATA_FILE_NAME
+        )
         if not metadata_path.exists():
-            logger.warning(f"Metadata file not found for tool '{tool_name}' version '{actual_version_str}' at {metadata_path}")
+            logger.warning(
+                f"Metadata file not found for tool '{tool_name}' version '{actual_version_str}' at {metadata_path}"
+            )
             return None
         try:
             with open(metadata_path, "r", encoding="utf-8") as f:
                 return json.load(f)
         except (IOError, json.JSONDecodeError) as e:
-            logger.error(f"Error reading metadata for tool '{tool_name}' version '{actual_version_str}': {e}")
+            logger.error(
+                f"Error reading metadata for tool '{tool_name}' version '{actual_version_str}': {e}"
+            )
             return None
 
     def unregister(self, tool_name: str, version: Optional[str] = None) -> bool:
         tool_name_sanitized = tool_name.replace("-", "_").replace(" ", "_").lower()
         tool_package_dir = self._get_tool_package_dir(tool_name_sanitized)
         if not tool_package_dir.exists():
-            logger.warning(f"Tool '{tool_name}' (directory {tool_package_dir}) not found for unregistration.")
+            logger.warning(
+                f"Tool '{tool_name}' (directory {tool_package_dir}) not found for unregistration."
+            )
             return False
         if version:
             actual_version_str = version
             version_sanitized = "v" + actual_version_str.replace(".", "_")
-            tool_version_dir = self._get_tool_version_dir(tool_name_sanitized, version_sanitized)
+            tool_version_dir = self._get_tool_version_dir(
+                tool_name_sanitized, version_sanitized
+            )
             if tool_version_dir.exists():
                 try:
                     shutil.rmtree(tool_version_dir)
-                    logger.info(f"Unregistered tool '{tool_name}' version '{actual_version_str}'.")
-                    remaining_items = [item for item in tool_package_dir.iterdir() if item.name != "__init__.py"]
+                    logger.info(
+                        f"Unregistered tool '{tool_name}' version '{actual_version_str}'."
+                    )
+                    remaining_items = [
+                        item
+                        for item in tool_package_dir.iterdir()
+                        if item.name != "__init__.py"
+                    ]
                     if not remaining_items:
-                        logger.info(f"Parent directory for '{tool_name}' is empty, removing {tool_package_dir}.")
+                        logger.info(
+                            f"Parent directory for '{tool_name}' is empty, removing {tool_package_dir}."
+                        )
                         shutil.rmtree(tool_package_dir)
                     return True
                 except OSError as e:
-                    logger.error(f"Error unregistering tool '{tool_name}' version '{actual_version_str}': {e}")
+                    logger.error(
+                        f"Error unregistering tool '{tool_name}' version '{actual_version_str}': {e}"
+                    )
                     return False
             else:
-                logger.warning(f"Tool '{tool_name}' version '{actual_version_str}' not found for unregistration at {tool_version_dir}.")
+                logger.warning(
+                    f"Tool '{tool_name}' version '{actual_version_str}' not found for unregistration at {tool_version_dir}."
+                )
                 return False
         else:
             try:
                 shutil.rmtree(tool_package_dir)
-                logger.info(f"Unregistered all versions of tool '{tool_name}' by removing {tool_package_dir}.")
+                logger.info(
+                    f"Unregistered all versions of tool '{tool_name}' by removing {tool_package_dir}."
+                )
                 return True
             except OSError as e:
-                logger.error(f"Error unregistering all versions of tool '{tool_name}': {e}")
+                logger.error(
+                    f"Error unregistering all versions of tool '{tool_name}': {e}"
+                )
                 return False
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     import sys
+
     current_file_path = Path(__file__).resolve()
-    project_root = current_file_path.parent.parent.parent 
+    project_root = current_file_path.parent.parent.parent
     src_path = project_root / "src"
     if str(src_path) not in sys.path:
         sys.path.insert(0, str(src_path))
@@ -315,30 +416,45 @@ def get_tool_instance(): # A common entry point convention
     return GreeterTool(salutation="Greetings")
 """
     tool_spec = {
-        "input_schema": {"type": "object", "properties": {"name": {"type": "string", "description": "Name to greet"}}},
-        "output_schema": {"type": "string", "description": "A greeting message"}
+        "input_schema": {
+            "type": "object",
+            "properties": {"name": {"type": "string", "description": "Name to greet"}},
+        },
+        "output_schema": {"type": "string", "description": "A greeting message"},
     }
-    my_tool = GeneratedTool(name="MyExampleGreeter", description="A simple greeter tool for testing.", code=sample_tool_code, specification=tool_spec)
+    my_tool = GeneratedTool(
+        name="MyExampleGreeter",
+        description="A simple greeter tool for testing.",
+        code=sample_tool_code,
+        specification=tool_spec,
+    )
     print("\n--- Registering Tool ---")
     module_path_v1 = registry.register(my_tool, version="0.1.0")
     if module_path_v1:
         print(f"Registered MyExampleGreeter v0.1.0 at module: {module_path_v1}")
     my_tool_v2_code = sample_tool_code.replace("GreeterTool!", "GreeterTool V2!")
-    my_tool_v2 = GeneratedTool(name="MyExampleGreeter", description="V2 of greeter.", code=my_tool_v2_code, specification=tool_spec)
+    my_tool_v2 = GeneratedTool(
+        name="MyExampleGreeter",
+        description="V2 of greeter.",
+        code=my_tool_v2_code,
+        specification=tool_spec,
+    )
     module_path_v2 = registry.register(my_tool_v2, version="0.2.0")
     if module_path_v2:
-         print(f"Registered MyExampleGreeter v0.2.0 at module: {module_path_v2}")
+        print(f"Registered MyExampleGreeter v0.2.0 at module: {module_path_v2}")
     print("\n--- Listing Tools ---")
     tools_list = registry.list_tools()
     print(json.dumps(tools_list, indent=2))
-    assert any(t['name'] == 'MyExampleGreeter' for t in tools_list), "MyExampleGreeter not found in list"
+    assert any(
+        t["name"] == "MyExampleGreeter" for t in tools_list
+    ), "MyExampleGreeter not found in list"
     print("\n--- Loading Tool v0.1.0 ---")
     loaded_tool_module_v1 = registry.load("MyExampleGreeter", version="0.1.0")
     assert loaded_tool_module_v1 is not None, "Failed to load MyExampleGreeter v0.1.0"
     if loaded_tool_module_v1:
-        if hasattr(loaded_tool_module_v1, 'get_tool_instance'):
+        if hasattr(loaded_tool_module_v1, "get_tool_instance"):
             greeter_instance_v1 = loaded_tool_module_v1.get_tool_instance()
-            result_v1 = greeter_instance_v1.run('Alice')
+            result_v1 = greeter_instance_v1.run("Alice")
             print(f"v0.1.0 output: {result_v1}")
             assert "Greetings, Alice from GreeterTool!" in result_v1
         else:
@@ -347,9 +463,9 @@ def get_tool_instance(): # A common entry point convention
     latest_tool_module = registry.load("MyExampleGreeter", version="latest")
     assert latest_tool_module is not None, "Failed to load latest MyExampleGreeter"
     if latest_tool_module:
-        if hasattr(latest_tool_module, 'get_tool_instance'):
+        if hasattr(latest_tool_module, "get_tool_instance"):
             latest_greeter_instance = latest_tool_module.get_tool_instance()
-            result_latest = latest_greeter_instance.run('Bob')
+            result_latest = latest_greeter_instance.run("Bob")
             print(f"Latest output: {result_latest}")
             assert "Greetings, Bob from GreeterTool V2!" in result_latest
         else:
@@ -358,22 +474,37 @@ def get_tool_instance(): # A common entry point convention
     metadata_v1 = registry.get_tool_metadata("MyExampleGreeter", "0.1.0")
     if metadata_v1:
         print(json.dumps(metadata_v1, indent=2))
-        assert metadata_v1['version'] == '0.1.0'
+        assert metadata_v1["version"] == "0.1.0"
     print("\n--- Unregistering Tool v0.1.0 ---")
     unreg_v1_success = registry.unregister("MyExampleGreeter", version="0.1.0")
     assert unreg_v1_success, "Failed to unregister v0.1.0"
     tools_list_after_unregister_v1 = registry.list_tools()
-    print("List after unregistering v0.1.0:", json.dumps(tools_list_after_unregister_v1, indent=2))
-    my_greeter_info = next((t for t in tools_list_after_unregister_v1 if t['name'] == 'MyExampleGreeter'), None)
+    print(
+        "List after unregistering v0.1.0:",
+        json.dumps(tools_list_after_unregister_v1, indent=2),
+    )
+    my_greeter_info = next(
+        (t for t in tools_list_after_unregister_v1 if t["name"] == "MyExampleGreeter"),
+        None,
+    )
     if my_greeter_info:
-      assert not any(v['version'] == '0.1.0' for v in my_greeter_info['versions']), "v0.1.0 still found"
-      assert any(v['version'] == '0.2.0' for v in my_greeter_info['versions']), "v0.2.0 not found"
+        assert not any(
+            v["version"] == "0.1.0" for v in my_greeter_info["versions"]
+        ), "v0.1.0 still found"
+        assert any(
+            v["version"] == "0.2.0" for v in my_greeter_info["versions"]
+        ), "v0.2.0 not found"
     else:
-      pass 
+        pass
     print("\n--- Unregistering All Versions of MyExampleGreeter ---")
     unreg_all_success = registry.unregister("MyExampleGreeter")
     assert unreg_all_success, "Failed to unregister all versions of MyExampleGreeter"
     tools_list_after_full_unregister = registry.list_tools()
-    print("List after unregistering all:", json.dumps(tools_list_after_full_unregister, indent=2))
-    assert not any(t['name'] == 'MyExampleGreeter' for t in tools_list_after_full_unregister), "MyExampleGreeter still found after full unregistration"
+    print(
+        "List after unregistering all:",
+        json.dumps(tools_list_after_full_unregister, indent=2),
+    )
+    assert not any(
+        t["name"] == "MyExampleGreeter" for t in tools_list_after_full_unregister
+    ), "MyExampleGreeter still found after full unregistration"
     print("\nTool Registry example script finished successfully.")

--- a/src/meta_agent/services/llm_service.py
+++ b/src/meta_agent/services/llm_service.py
@@ -18,20 +18,26 @@ import backoff
 
 load_dotenv()
 
+
 class LLMService:
     """
     Handles communication with LLM APIs for code generation.
-    
+
     This class is responsible for making API calls to LLM providers,
     handling errors and retries, and extracting code from responses.
     """
-    
-    def __init__(self, api_key: Optional[str] = None, model: str = "o4-mini", 
-                 max_retries: int = 3, timeout: int = 30,
-                 api_base: Optional[str] = None):
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: str = "o4-mini",
+        max_retries: int = 3,
+        timeout: int = 30,
+        api_base: Optional[str] = None,
+    ):
         """
         Initialize the LLMService.
-        
+
         Args:
             api_key: API key for the LLM provider. If None, attempts to load from OPENAI_API_KEY env var.
             model: Model to use for code generation
@@ -41,37 +47,41 @@ class LLMService:
         """
         if api_key is None:
             api_key = os.getenv("OPENAI_API_KEY")
-        
+
         if not api_key:
-            raise ValueError("OpenAI API key not provided and not found in environment variables (OPENAI_API_KEY).")
-            
+            raise ValueError(
+                "OpenAI API key not provided and not found in environment variables (OPENAI_API_KEY)."
+            )
+
         self.api_key = api_key
         self.model = model
         self.max_retries = max_retries
         self.timeout = timeout
         self.api_base = api_base or "https://api.openai.com/v1/responses"
         self.logger = logging.getLogger(__name__)
-        
+
     async def generate_code(self, prompt: str, context: Dict[str, Any]) -> str:
         """
         Generate code using the LLM API.
-        
+
         This method sends a prompt to the LLM API and returns the generated code.
         It includes retry logic with exponential backoff for handling API errors.
-        
+
         Args:
             prompt: The prompt to send to the LLM
             context: Additional context for the LLM
-            
+
         Returns:
             str: The generated code
-            
+
         Raises:
             Exception: If code generation fails after all retries
         """
         for attempt in range(self.max_retries):
             try:
-                self.logger.info(f"Calling LLM API (attempt {attempt + 1}/{self.max_retries})")
+                self.logger.info(
+                    f"Calling LLM API (attempt {attempt + 1}/{self.max_retries})"
+                )
                 response = await self._call_llm_api(prompt, context)
                 code = self._extract_code_from_response(response)
                 if code:
@@ -85,32 +95,34 @@ class LLMService:
                 self.logger.error(f"Error during LLM API call: {str(e)}", exc_info=True)
                 if attempt == self.max_retries - 1:
                     raise e
-                
+
                 # Exponential backoff
-                backoff_time = 2 ** attempt
+                backoff_time = 2**attempt
                 self.logger.info(f"Retrying in {backoff_time} seconds...")
                 await asyncio.sleep(backoff_time)
-        
+
         # This should never be reached due to the raise in the loop
         raise RuntimeError("Failed to generate code after all retries")
-    
-    @backoff.on_exception(backoff.expo, 
-                         (aiohttp.ClientError, asyncio.TimeoutError),
-                         max_tries=3)
-    async def _call_llm_api(self, prompt: str, context: Dict[str, Any]) -> Dict[str, Any]:
+
+    @backoff.on_exception(
+        backoff.expo, (aiohttp.ClientError, asyncio.TimeoutError), max_tries=3
+    )
+    async def _call_llm_api(
+        self, prompt: str, context: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         Call the LLM API with the given prompt and context.
-        
+
         This method constructs the API request, sends it to the LLM provider,
         and returns the response.
-        
+
         Args:
             prompt: The prompt to send to the LLM
             context: Additional context for the LLM
-            
+
         Returns:
             Dict[str, Any]: The API response
-            
+
         Raises:
             aiohttp.ClientError: If the API call fails
             asyncio.TimeoutError: If the API call times out
@@ -118,66 +130,72 @@ class LLMService:
         """
         # Prepare the messages for the API
         messages = [
-            {"role": "system", "content": "You are an expert Python developer tasked with implementing tools based on specifications."}
+            {
+                "role": "system",
+                "content": "You are an expert Python developer tasked with implementing tools based on specifications.",
+            }
         ]
-        
+
         # Add context as a system message if provided
         if context:
             context_str = json.dumps(context, indent=2)
-            messages.append({
-                "role": "system", 
-                "content": f"Here is additional context for the implementation:\n{context_str}"
-            })
-        
+            messages.append(
+                {
+                    "role": "system",
+                    "content": f"Here is additional context for the implementation:\n{context_str}",
+                }
+            )
+
         # Add the main prompt as a user message
         messages.append({"role": "user", "content": prompt})
-        
+
         # Prepare the API request payload
         payload = {
             "model": self.model,
             "input": messages,
             "max_output_tokens": 2000,  # Adjust based on expected code length
         }
-        
+
         # Set up headers
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.api_key}"
+            "Authorization": f"Bearer {self.api_key}",
         }
-        
+
         # Make the API call
         session = aiohttp.ClientSession()
         try:
-            async with session.post(
+            request_ctx = await session.post(
                 self.api_base,
                 headers=headers,
                 json=payload,
-                timeout=self.timeout
-            ) as response:
+                timeout=self.timeout,
+            )
+            async with request_ctx as response:
                 if response.status != 200:
                     error_text = await response.text()
                     self.logger.error(f"API error: {response.status} - {error_text}")
-                    raise ValueError(f"API returned error: {response.status} - {error_text}")
+                    raise ValueError(f"API error: {response.status} - {error_text}")
 
                 result = await response.json()
                 return result
         finally:
             await session.close()
-    
+
     def _extract_code_from_response(self, response: Dict[str, Any]) -> str:
         """
         Extract code from the LLM response.
-        
+
         This method parses the LLM response to extract the generated code,
         handling different response formats and code block markers.
-        
+
         Args:
             response: The API response from the LLM
-            
+
         Returns:
             str: The extracted code, or an empty string if extraction fails
         """
-        content_str = "" 
+        content_str = ""
         try:
             if isinstance(response.get("output"), list):
                 for item in response["output"]:
@@ -185,7 +203,9 @@ class LLMService:
                         content = None
                         if isinstance(item.get("content"), list) and item["content"]:
                             first = item["content"][0]
-                            if isinstance(first, dict) and isinstance(first.get("text"), str):
+                            if isinstance(first, dict) and isinstance(
+                                first.get("text"), str
+                            ):
                                 content = first["text"]
                         elif isinstance(item.get("text"), str):
                             content = item["text"]
@@ -197,50 +217,60 @@ class LLMService:
                 self.logger.error(
                     "Failed to extract content string from 'responses' endpoint. Expected 'output' list with a 'message' type item containing 'output_text'."
                 )
-                self.logger.debug(f"Full response for debugging: {json.dumps(response, indent=2)}")
+                self.logger.debug(
+                    f"Full response for debugging: {json.dumps(response, indent=2)}"
+                )
                 return ""
 
         except (KeyError, IndexError, TypeError) as e:
-            self.logger.error(f"Error accessing content from 'responses' API structure: {e}")
-            self.logger.debug(f"Full response for debugging: {json.dumps(response, indent=2)}")
+            self.logger.error(
+                f"Error accessing content from 'responses' API structure: {e}"
+            )
+            self.logger.debug(
+                f"Full response for debugging: {json.dumps(response, indent=2)}"
+            )
             return ""
-        
+
         try:
             # Try to extract code blocks with Python markers
             python_blocks = re.findall(r"```python\n(.*?)```", content_str, re.DOTALL)
             if python_blocks:
                 return python_blocks[0].strip()
-            
+
             # Try to extract any code blocks
             code_blocks = re.findall(r"```(.*?)```", content_str, re.DOTALL)
             if code_blocks:
                 return code_blocks[0].strip()
-            
+
             # If no code blocks found, try to extract based on common patterns
             lines = content_str.split("\n")
             code_lines = []
             in_code = False
-            
+
             for line in lines:
                 # Skip markdown headers and explanations
                 if line.startswith("#") or ":" in line[:20]:
                     continue
-                
+
                 # Skip empty lines at the beginning
                 if not in_code and not line.strip():
                     continue
-                
+
                 # Once we start collecting code, we're in code mode
                 in_code = True
                 code_lines.append(line)
-            
+
             if code_lines:
                 return "\n".join(code_lines).strip()
-            
+
             # If all else fails, return the entire content
-            self.logger.warning("Could not extract specific code blocks, returning full content")
+            self.logger.warning(
+                "Could not extract specific code blocks, returning full content"
+            )
             return content_str.strip()
-            
+
         except Exception as e:
-            self.logger.error(f"Error extracting code from response: {str(e)}", exc_info=True)
+            self.logger.error(
+                f"Error extracting code from response: {str(e)}", exc_info=True
+            )
             return ""


### PR DESCRIPTION
## Summary
- adjust llm_service API call for mocks
- enhance orchestrator results
- fix tool registry loading helpers
- import asyncio in llm_service tests

## Testing
- `ruff check src/meta_agent/services/llm_service.py src/meta_agent/orchestrator.py tests/unit/test_llm_service_api.py src/meta_agent/registry.py`
- `black src/meta_agent/services/llm_service.py src/meta_agent/orchestrator.py tests/unit/test_llm_service_api.py src/meta_agent/registry.py`
- `pytest tests/unit/test_llm_service_api.py -q`
- `pytest tests/integration/test_tool_lifecycle.py::test_tool_refinement_major_version_bump -q`
- `pytest tests/integration/test_tool_lifecycle.py::test_tool_refinement_version_bump tests/integration/test_tool_lifecycle.py::test_subagent_manager_create_tool -q`
- `pytest tests/integration/test_orchestrator_integration.py::test_orchestrator_integration_flow -q`
- `pytest tests/test_cli.py::test_cli_generate_spec_file_json -q` *(fails)*