### PR TITLE
fix: stable tool lifecycle tests

### DIFF
--- a/src/meta_agent/cli/main.py
+++ b/src/meta_agent/cli/main.py
@@ -7,6 +7,7 @@ import sys
 import yaml
 import json
 import asyncio
+import logging
 from pathlib import Path
 from pydantic import ValidationError
 
@@ -16,7 +17,9 @@ from meta_agent.planning_engine import PlanningEngine
 from meta_agent.sub_agent_manager import SubAgentManager
 from meta_agent.registry import ToolRegistry
 from meta_agent.tool_designer import ToolDesignerAgent
+
 # TODO: Import logging setup from utils
+
 
 @click.group()
 def cli():
@@ -24,17 +27,22 @@ def cli():
     # TODO: Configure logging
     pass
 
-@click.option('--spec-file', type=click.Path(exists=True, dir_okay=False, path_type=Path), 
-              help='Path to the specification file (JSON or YAML).')
-@click.option('--spec-text', type=str, 
-              help='Specification provided as a text string.')
+
+@click.option(
+    "--spec-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to the specification file (JSON or YAML).",
+)
+@click.option("--spec-text", type=str, help="Specification provided as a text string.")
 async def generate(spec_file: Path | None, spec_text: str | None):
     """Generate agent code based on a specification."""
     if not spec_file and not spec_text:
         click.echo("Error: Please provide either --spec-file or --spec-text.", err=True)
         sys.exit(1)
     if spec_file and spec_text:
-        click.echo("Error: Please provide only one of --spec-file or --spec-text.", err=True)
+        click.echo(
+            "Error: Please provide only one of --spec-file or --spec-text.", err=True
+        )
         sys.exit(1)
 
     spec: SpecSchema | None = None
@@ -43,14 +51,19 @@ async def generate(spec_file: Path | None, spec_text: str | None):
     try:
         if spec_file:
             click.echo(f"Reading specification from file: {spec_file}")
-            raw_spec_data = spec_file # Keep path for now, parsing happens in SpecSchema
-            if spec_file.suffix.lower() == '.json':
+            raw_spec_data = (
+                spec_file  # Keep path for now, parsing happens in SpecSchema
+            )
+            if spec_file.suffix.lower() == ".json":
                 spec = SpecSchema.from_json(spec_file)
-            elif spec_file.suffix.lower() in ['.yaml', '.yml']:
+            elif spec_file.suffix.lower() in [".yaml", ".yml"]:
                 spec = SpecSchema.from_yaml(spec_file)
             else:
                 # TODO: Add support for attempting text parse from unknown file types?
-                click.echo(f"Error: Unsupported file type: {spec_file.suffix}. Please use JSON or YAML.", err=True)
+                click.echo(
+                    f"Error: Unsupported file type: {spec_file.suffix}. Please use JSON or YAML.",
+                    err=True,
+                )
                 sys.exit(1)
 
         elif spec_text:
@@ -77,13 +90,13 @@ async def generate(spec_file: Path | None, spec_text: str | None):
                     click.echo("Parsing spec-text as free-form text.")
                     spec = SpecSchema.from_text(spec_text)
             except ValidationError as e:
-                 click.echo(f"Error validating structured text input: {e}", err=True)
-                 sys.exit(1)
+                click.echo(f"Error validating structured text input: {e}", err=True)
+                sys.exit(1)
 
         if spec:
             click.echo("Specification parsed successfully:")
             # TODO: Implement actual agent generation logic (later tasks)
-            click.echo(f"  Task Description: {spec.task_description[:100]}...") 
+            click.echo(f"  Task Description: {spec.task_description[:100]}...")
             click.echo(f"  Inputs: {spec.inputs}")
             click.echo(f"  Outputs: {spec.outputs}")
             # Instantiate components
@@ -102,13 +115,13 @@ async def generate(spec_file: Path | None, spec_text: str | None):
             # Run the orchestration
             click.echo("\nStarting agent generation orchestration...")
             # Convert Pydantic model to dict for the orchestrator
-            spec_dict = spec.model_dump(exclude_unset=True) 
+            spec_dict = spec.model_dump(exclude_unset=True)
             results = await orchestrator.run(specification=spec_dict)
             click.echo("\nOrchestration finished.")
             click.echo(f"Results: {json.dumps(results, indent=2)}")
 
         else:
-             # This case should ideally not be reached due to prior checks/errors
+            # This case should ideally not be reached due to prior checks/errors
             click.echo("Error: Could not parse or load specification.", err=True)
             sys.exit(1)
 
@@ -124,78 +137,100 @@ async def generate(spec_file: Path | None, spec_text: str | None):
         # TODO: Add proper logging here
         sys.exit(1)
 
+
 # Note: This basic setup works for a single async command.
 # If more async commands are added, a more robust asyncio setup might be needed.
-@cli.command(name='generate')
-@click.option('--spec-file', type=click.Path(exists=True, dir_okay=False, path_type=Path), 
-              help='Path to the specification file (JSON or YAML).')
-@click.option('--spec-text', type=str, 
-              help='Specification provided as a text string.')
+@cli.command(name="generate")
+@click.option(
+    "--spec-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to the specification file (JSON or YAML).",
+)
+@click.option("--spec-text", type=str, help="Specification provided as a text string.")
 def generate_command_wrapper(spec_file, spec_text):
-    asyncio.run(generate(spec_file, spec_text))
+    """Synchronous wrapper for the async ``generate`` command."""
+    root_logger = logging.getLogger()
+    saved_handlers = root_logger.handlers[:]
+    root_logger.handlers = []
+    try:
+        asyncio.run(generate(spec_file, spec_text))
+    finally:
+        root_logger.handlers = saved_handlers
+
 
 async def create_tool(spec_file: Path, use_llm: bool, version: str):
     """Create a tool based on a specification file."""
     click.echo(f"Reading tool specification from file: {spec_file}")
-    
+
     try:
         # Parse the specification file
         tool_spec = None
-        if spec_file.suffix.lower() == '.json':
-            with open(spec_file, 'r') as f:
+        if spec_file.suffix.lower() == ".json":
+            with open(spec_file, "r") as f:
                 tool_spec = json.load(f)
             click.echo("Parsed tool specification from JSON file.")
-        elif spec_file.suffix.lower() in ['.yaml', '.yml']:
-            with open(spec_file, 'r') as f:
+        elif spec_file.suffix.lower() in [".yaml", ".yml"]:
+            with open(spec_file, "r") as f:
                 tool_spec = yaml.safe_load(f)
             click.echo("Parsed tool specification from YAML file.")
         else:
-            click.echo(f"Error: Unsupported file type: {spec_file.suffix}. Please use JSON or YAML.", err=True)
+            click.echo(
+                f"Error: Unsupported file type: {spec_file.suffix}. Please use JSON or YAML.",
+                err=True,
+            )
             sys.exit(1)
-        
+
         if not tool_spec:
             click.echo("Error: Empty or invalid tool specification.", err=True)
             sys.exit(1)
-        
+
         # Validate basic structure
         if not isinstance(tool_spec, dict):
-            click.echo("Error: Tool specification must be a dictionary/object.", err=True)
+            click.echo(
+                "Error: Tool specification must be a dictionary/object.", err=True
+            )
             sys.exit(1)
-        
+
         if "name" not in tool_spec:
-            click.echo("Error: Tool specification must include a 'name' field.", err=True)
+            click.echo(
+                "Error: Tool specification must include a 'name' field.", err=True
+            )
             sys.exit(1)
-        
+
         # Initialize components
         click.echo("Initializing components for tool creation...")
         sub_agent_manager = SubAgentManager()
         tool_registry = ToolRegistry()
         tool_designer_agent = ToolDesignerAgent()
-        
+
         # Create the tool
         click.echo(f"Creating tool '{tool_spec.get('name')}' (version {version})...")
         if use_llm:
             click.echo("Using LLM for code generation (--use-llm flag enabled).")
             # Note: Currently the LLM is always used in the implementation,
             # but we keep the flag for future flexibility
-        
+
         module_path = await sub_agent_manager.create_tool(
             spec=tool_spec,
             version=version,
             tool_registry=tool_registry,
-            tool_designer_agent=tool_designer_agent
+            tool_designer_agent=tool_designer_agent,
         )
-        
+
         if module_path:
-            click.echo(click.style(f"\n✓ Tool created successfully!", fg="green", bold=True))
+            click.echo(
+                click.style(f"\n✓ Tool created successfully!", fg="green", bold=True)
+            )
             click.echo(f"Module path: {module_path}")
-            click.echo(f"You can import this tool using: from {module_path} import get_tool_instance")
+            click.echo(
+                f"You can import this tool using: from {module_path} import get_tool_instance"
+            )
             return module_path
         else:
             click.echo(click.style("\n✗ Tool creation failed.", fg="red", bold=True))
             click.echo("Check the logs for more details on the failure.")
             sys.exit(1)
-            
+
     except FileNotFoundError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
@@ -206,34 +241,49 @@ async def create_tool(spec_file: Path, use_llm: bool, version: str):
         click.echo(f"An unexpected error occurred: {e}", err=True)
         sys.exit(1)
 
-@cli.command(name='tool')
-@click.argument('action', type=click.Choice(['create', 'list', 'delete']))
-@click.option('--spec-file', type=click.Path(exists=True, dir_okay=False, path_type=Path),
-              help='Path to the tool specification file (JSON or YAML).')
-@click.option('--use-llm', is_flag=True, default=True,
-              help='Use LLM for code generation (default: enabled).')
-@click.option('--version', type=str, default="0.1.0",
-              help='Version for the created tool (default: 0.1.0).')
+
+@cli.command(name="tool")
+@click.argument("action", type=click.Choice(["create", "list", "delete"]))
+@click.option(
+    "--spec-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to the tool specification file (JSON or YAML).",
+)
+@click.option(
+    "--use-llm",
+    is_flag=True,
+    default=True,
+    help="Use LLM for code generation (default: enabled).",
+)
+@click.option(
+    "--version",
+    type=str,
+    default="0.1.0",
+    help="Version for the created tool (default: 0.1.0).",
+)
 def tool_command_wrapper(action, spec_file, use_llm, version):
     """
     Manage tools for the meta-agent.
-    
+
     ACTION can be one of:
-    
+
     \b
     create: Create a new tool from a specification file
     list: List all available tools (not implemented yet)
     delete: Delete a tool (not implemented yet)
     """
-    if action == 'create':
+    if action == "create":
         if not spec_file:
-            click.echo("Error: --spec-file is required for the 'create' action.", err=True)
+            click.echo(
+                "Error: --spec-file is required for the 'create' action.", err=True
+            )
             sys.exit(1)
         asyncio.run(create_tool(spec_file, use_llm, version))
-    elif action == 'list':
+    elif action == "list":
         click.echo("Tool listing is not implemented yet.")
-    elif action == 'delete':
+    elif action == "delete":
         click.echo("Tool deletion is not implemented yet.")
+
 
 if __name__ == "__main__":
     cli()

--- a/src/meta_agent/orchestrator.py
+++ b/src/meta_agent/orchestrator.py
@@ -530,6 +530,11 @@ class MetaAgentOrchestrator:
                 logger.info(f"Executing task {task_id} using agent {sub_agent.name}...")
                 try:
                     sub_agent_output = await sub_agent.run(specification=task_req)
+                    if not isinstance(sub_agent_output, dict):
+                        sub_agent_output = {
+                            "output": sub_agent_output,
+                            "status": "completed",
+                        }
                     result_status = sub_agent_output.get("status", "unknown")
                     logger.info(
                         f"Task {task_id} completed by {sub_agent.name}. Result: {result_status}"

--- a/src/meta_agent/registry.py
+++ b/src/meta_agent/registry.py
@@ -185,6 +185,14 @@ class ToolRegistry:
                 if spec and spec.loader:
                     spec.loader.exec_module(pkg)
 
+            # Ensure subpackage for this tool includes the new path
+            subpkg_name = f"{pkg_name}.{tool_name_sanitized}"
+            subpkg_path = str(self.tools_dir / tool_name_sanitized)
+            if subpkg_name in sys.modules:
+                subpkg = sys.modules[subpkg_name]
+                if hasattr(subpkg, "__path__") and subpkg_path not in subpkg.__path__:
+                    subpkg.__path__.append(subpkg_path)
+
             logger.info(f"[DIAGNOSTIC] Attempting to import: {module_full_path}")
             logger.info(f"[DIAGNOSTIC] Current sys.path: {sys.path}")
             tool_module = importlib.import_module(module_full_path)


### PR DESCRIPTION
## Summary
- clean up logging handler side effects when running the CLI
- coerce sub-agent results to a dict in `_execute_plan`
- update ToolRegistry loader so tests work across multiple base paths

## Testing
- `ruff check .` *(fails: F401 etc.)*
- `black --check .` *(fails: would reformat many files)*
- `mypy src/meta_agent` *(fails: several errors)*
- `pyright` *(fails: many errors)*
- `pytest -q`