### PR TITLE
ci: add pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,20 @@
+name: pytest
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: Run test suite
+        run: pytest -v --cov=src/meta_agent tests


### PR DESCRIPTION
## Summary
- add GitHub action to run pytest on pull requests to `main`

## Testing
- `ruff check .` *(fails: found 185 errors)*
- `black --check .` *(fails: would reformat many files)*
- `pytest` *(fails: command not found)*
- `mypy .` *(fails: found 49 errors)*
- `pyright` *(fails: 139 errors)*