### PR TITLE
feat: implement basic test generation

### DIFF
--- a/src/meta_agent/agents/tool_designer_agent.py
+++ b/src/meta_agent/agents/tool_designer_agent.py
@@ -7,11 +7,11 @@ import jinja2
 
 # Mapping from spec type strings to Python types
 TYPE_MAP = {
-    'integer': 'int',
-    'string': 'str',
-    'float': 'float',
-    'boolean': 'bool',
-    'any': 'Any'
+    "integer": "int",
+    "string": "str",
+    "float": "float",
+    "boolean": "bool",
+    "any": "Any",
 }
 
 # --- Import base Agent, handling potential unavailability ---
@@ -19,11 +19,19 @@ try:
     from agents import Agent
 except ImportError:
     logging.warning("Failed to import 'Agent' from agents library. Using placeholder.")
-    class Agent:
-        def __init__(self, name=None, *args, **kwargs): pass
-        async def run(self, *args, **kwargs): return {"error": "Base Agent class not available"}
 
-from meta_agent.parsers.tool_spec_parser import ToolSpecificationParser
+    class Agent:
+        def __init__(self, name=None, *args, **kwargs):
+            pass
+
+        async def run(self, *args, **kwargs):
+            return {"error": "Base Agent class not available"}
+
+
+from meta_agent.parsers.tool_spec_parser import (
+    ToolSpecificationParser,
+    ToolSpecification,
+)
 from meta_agent.generators.tool_code_generator import CodeGenerationError
 from meta_agent.models.generated_tool import GeneratedTool
 
@@ -36,25 +44,28 @@ from meta_agent.generators.implementation_injector import ImplementationInjector
 from meta_agent.generators.fallback_manager import FallbackManager
 from meta_agent.generators.prompt_templates import PROMPT_TEMPLATES
 from meta_agent.services.llm_service import LLMService
+from meta_agent.generators.test_generator import generate_basic_tests
 
 logger = logging.getLogger(__name__)
 
-class ToolDesignerAgent(Agent): # Inherit from Agent
+
+class ToolDesignerAgent(Agent):  # Inherit from Agent
     """Orchestrates the process of parsing a tool specification and generating code."""
 
-    def __init__(self, 
-                 model_name: str = "o4-mini-high", 
-                 template_dir: Optional[str] = None,
-                 template_name: str = "tool_template.py.j2",
-                 llm_api_key: Optional[str] = None, 
-                 llm_model: str = "gpt-4", 
-                 examples_repository: Optional[Dict[str, Any]] = None,
-                 ):
+    def __init__(
+        self,
+        model_name: str = "o4-mini-high",
+        template_dir: Optional[str] = None,
+        template_name: str = "tool_template.py.j2",
+        llm_api_key: Optional[str] = None,
+        llm_model: str = "gpt-4",
+        examples_repository: Optional[Dict[str, Any]] = None,
+    ):
         """Initializes the Tool Designer Agent.
 
         Args:
             model_name (str): The name of the language model to use (if needed, e.g., for future LLM generation).
-            template_dir (Optional[str]): Path to the directory containing Jinja2 templates. 
+            template_dir (Optional[str]): Path to the directory containing Jinja2 templates.
                                          Defaults to '../templates' relative to this file.
             template_name (str): The name of the Jinja2 template file to use.
                                 Defaults to 'tool_template.py.j2'.
@@ -62,46 +73,66 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
             llm_model (str): The model to use for LLM-backed generation.
             examples_repository (Optional[Dict[str, Any]]): Repository of example tools for reference.
         """
-        super().__init__(name="ToolDesignerAgent", tools=[]) # Initialize base Agent with name
+        super().__init__(
+            name="ToolDesignerAgent", tools=[]
+        )  # Initialize base Agent with name
         self.model_name = model_name
         self.template_name = template_name
-        self.llm_api_key = llm_api_key 
+        self.llm_api_key = llm_api_key
         self.llm_model = llm_model
         self.examples_repository = examples_repository or {}
 
         # Determine template directory
         if template_dir is None:
-            self.template_dir = os.path.join(os.path.dirname(__file__), '..', 'templates')
+            self.template_dir = os.path.join(
+                os.path.dirname(__file__), "..", "templates"
+            )
         else:
             self.template_dir = template_dir
 
         # --- Jinja2 Environment Setup ---
         self.jinja_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(self.template_dir),
-            autoescape=jinja2.select_autoescape(['html', 'xml'])
+            autoescape=jinja2.select_autoescape(["html", "xml"]),
         )
-        self.jinja_env.globals['map_type'] = lambda t: TYPE_MAP.get(t.lower(), t)
+        self.jinja_env.globals["map_type"] = lambda t: TYPE_MAP.get(t.lower(), t)
         logger.info(f"Jinja environment loaded from: {self.template_dir}")
-        
+
         # Always attempt to initialize LLM components.
         # _initialize_llm_components will handle cases where API key isn't available.
         self._initialize_llm_components(self.llm_api_key, self.llm_model)
+
+    def _generate_basic_docs(self, spec: ToolSpecification) -> str:
+        """Return minimal documentation for a generated tool."""
+        lines = [
+            f"# {spec.name}",
+            "",
+            spec.purpose,
+            "",
+            "## Inputs",
+        ]
+        for p in spec.input_parameters:
+            req = "(Required)" if p.required else "(Optional)"
+            lines.append(f"- {p.name}: {p.description or 'No description'} {req}")
+        lines.append("")
+        lines.append("## Output")
+        lines.append(str(spec.output_format))
+        return "\n".join(lines)
 
     def _initialize_llm_components(self, api_key: Optional[str], model: str):
         """Initialize the LLM-backed code generation components."""
         try:
             # LLMService will use api_key if provided, otherwise try os.getenv("OPENAI_API_KEY")
             # It will raise ValueError if no key is found.
-            self.llm_service = LLMService(api_key=api_key, model=model) 
-            
+            self.llm_service = LLMService(api_key=api_key, model=model)
+
             # Initialize other components that depend on llm_service
             self.prompt_builder = PromptBuilder(PROMPT_TEMPLATES)
             self.context_builder = ContextBuilder(self.examples_repository)
             self.code_validator = CodeValidator()
             self.implementation_injector = ImplementationInjector(self.jinja_env)
             self.fallback_manager = FallbackManager(
-                self.llm_service,
-                self.prompt_builder
+                self.llm_service, self.prompt_builder
             )
 
             self.llm_code_generator = LLMCodeGenerator(
@@ -110,21 +141,29 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
                 context_builder=self.context_builder,
                 code_validator=self.code_validator,
                 implementation_injector=self.implementation_injector,
-                fallback_manager=self.fallback_manager
+                fallback_manager=self.fallback_manager,
             )
-            logger.info("LLM-backed code generation components initialized successfully.")
+            logger.info(
+                "LLM-backed code generation components initialized successfully."
+            )
 
         except ValueError as e:
             # This typically means LLMService couldn't find an API key.
             self.llm_service = None
             self.llm_code_generator = None
-            logger.warning(f"Failed to initialize LLM components: {e}. LLM-backed generation will be disabled.")
+            logger.warning(
+                f"Failed to initialize LLM components: {e}. LLM-backed generation will be disabled."
+            )
         except Exception as e:
             # Catch any other unexpected errors during initialization
             self.llm_service = None
             self.llm_code_generator = None
-            logger.error(f"Unexpected error initializing LLM components: {e}", exc_info=True)
-            logger.warning("LLM-backed generation will be disabled due to an unexpected error.")
+            logger.error(
+                f"Unexpected error initializing LLM components: {e}", exc_info=True
+            )
+            logger.warning(
+                "LLM-backed generation will be disabled due to an unexpected error."
+            )
 
     def design_tool(self, specification: Union[str, Dict[str, Any]]) -> str:
         """Parses the specification and generates tool code using a Jinja2 template."""
@@ -136,12 +175,14 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
                 error_str = "; ".join(error_msgs)
                 # Don't wrap this in a try-except - let it propagate directly
                 raise ValueError(f"Invalid tool specification: {error_str}")
-            
+
             parsed_spec = parser.get_specification()
             if parsed_spec is None:
                 raise ValueError("Failed to parse tool specification")
-            
-            logger.info(f"Successfully parsed tool specification for: {parsed_spec.name}")
+
+            logger.info(
+                f"Successfully parsed tool specification for: {parsed_spec.name}"
+            )
 
             # 1.1. Map types to Python equivalents
             for param in parsed_spec.input_parameters:
@@ -149,21 +190,27 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
                 param.type_ = TYPE_MAP.get(lower, param.type_)
             # Map output_format
             out_lower = parsed_spec.output_format.lower()
-            parsed_spec.output_format = TYPE_MAP.get(out_lower, parsed_spec.output_format)
+            parsed_spec.output_format = TYPE_MAP.get(
+                out_lower, parsed_spec.output_format
+            )
 
             # 2. Load the configured template
             try:
                 template = self.jinja_env.get_template(self.template_name)
                 logger.debug(f"Loaded template: {self.template_name}")
             except jinja2.TemplateNotFound:
-                raise CodeGenerationError(f"Tool template '{self.template_name}' not found")
+                raise CodeGenerationError(
+                    f"Tool template '{self.template_name}' not found"
+                )
             except Exception as e:
                 raise CodeGenerationError(f"Failed to load template: {e}")
 
             # 3. Render the template with the specification data
             try:
                 generated_code = template.render(spec=parsed_spec)
-                logger.info(f"Successfully rendered template for tool: {parsed_spec.name}")
+                logger.info(
+                    f"Successfully rendered template for tool: {parsed_spec.name}"
+                )
                 return generated_code
             except Exception as e:
                 raise CodeGenerationError(f"Failed to render template: {e}")
@@ -179,24 +226,28 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
             logger.exception(f"Unexpected error in design_tool: {e}")
             raise CodeGenerationError(f"Unexpected error in design_tool: {e}")
 
-    async def design_tool_with_llm(self, specification: Union[str, Dict[str, Any]]) -> str:
+    async def design_tool_with_llm(
+        self, specification: Union[str, Dict[str, Any]]
+    ) -> str:
         """
         Parses the specification and generates tool code using LLM-backed code generation.
-        
+
         Args:
             specification: The tool specification, either as a string or dictionary
-            
+
         Returns:
             str: The generated tool code
-            
+
         Raises:
             ValueError: If the specification is invalid
             CodeGenerationError: If code generation fails
             RuntimeError: If LLM-backed generation is not available
         """
         if not self.llm_code_generator:
-            raise RuntimeError("LLM-backed code generation is not available. Please provide an API key.")
-        
+            raise RuntimeError(
+                "LLM-backed code generation is not available. Please provide an API key."
+            )
+
         try:
             # 1. Parse the specification
             parser = ToolSpecificationParser(specification)
@@ -204,23 +255,29 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
                 error_msgs = parser.get_errors()
                 error_str = "; ".join(error_msgs)
                 raise ValueError(f"Invalid tool specification: {error_str}")
-            
+
             parsed_spec = parser.get_specification()
             if parsed_spec is None:
                 raise ValueError("Failed to parse tool specification")
-            
-            logger.info(f"Successfully parsed tool specification for LLM generation: {parsed_spec.name}")
-            
+
+            logger.info(
+                f"Successfully parsed tool specification for LLM generation: {parsed_spec.name}"
+            )
+
             # 2. Generate code using LLM
             try:
                 logger.info("Generating code using LLM...")
-                generated_code = await self.llm_code_generator.generate_code(parsed_spec)
-                logger.info(f"Successfully generated code with LLM for tool: {parsed_spec.name}")
+                generated_code = await self.llm_code_generator.generate_code(
+                    parsed_spec
+                )
+                logger.info(
+                    f"Successfully generated code with LLM for tool: {parsed_spec.name}"
+                )
                 return generated_code
             except Exception as e:
                 logger.error(f"LLM code generation failed: {str(e)}", exc_info=True)
                 raise CodeGenerationError(f"LLM code generation failed: {str(e)}")
-                
+
         except ValueError:
             # Let ValueError propagate through directly
             raise
@@ -235,48 +292,67 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
     async def run(self, specification: Dict[str, Any]) -> Dict[str, Any]:
         """
         Runs the full tool design workflow: research, parse, generate.
-        
+
         Args:
             specification: Dictionary containing the tool specification and options
                           If 'use_llm' is True in the specification, LLM-backed generation will be used
-                          
+
         Returns:
             Dict[str, Any]: Result dictionary with status and output
         """
-        logger.info(f"ToolDesignerAgent received run request for: {specification.get('name', 'Unknown Tool')}")
-        
+        logger.info(
+            f"ToolDesignerAgent received run request for: {specification.get('name', 'Unknown Tool')}"
+        )
+
         # Extract the actual specification content
         spec_content = specification  # Assuming the dict *is* the spec for now
-        
+
         # Check if we should use LLM-backed generation
-        use_llm = specification.get('use_llm', False)
-        
+        use_llm = specification.get("use_llm", False)
+
         if not spec_content:
-             return {"status": "error", "error": "No specification provided to ToolDesignerAgent"}
-        
+            return {
+                "status": "error",
+                "error": "No specification provided to ToolDesignerAgent",
+            }
+
         try:
+            parser = ToolSpecificationParser(spec_content)
+            if not parser.parse():
+                error_msgs = parser.get_errors()
+                error_str = "; ".join(error_msgs)
+                return {
+                    "status": "error",
+                    "error": f"Invalid tool specification: {error_str}",
+                }
+
+            parsed_spec = parser.get_specification()
+            assert parsed_spec is not None
+
             # Generate Code
             if use_llm and self.llm_code_generator:
                 logger.info("Using LLM-backed code generation")
                 generated_code = await self.design_tool_with_llm(spec_content)
             else:
                 if use_llm and not self.llm_code_generator:
-                    logger.warning("LLM-backed generation requested but not available. Falling back to template-based generation.")
+                    logger.warning(
+                        "LLM-backed generation requested but not available. Falling back to template-based generation."
+                    )
                 logger.info("Using template-based code generation")
                 generated_code = self.design_tool(spec_content)
-                
+
             logger.info("Code generation successful.")
 
-            # Generate Tests and Docs (placeholders)
-            tests = "# TODO: Generate tests"
-            docs = """# TODO: Generate documentation"""
-            logger.debug("Using placeholder tests and docs.")
-            
+            # Generate basic tests and docs
+            tests = generate_basic_tests(parsed_spec)
+            docs = self._generate_basic_docs(parsed_spec)
+            logger.debug("Generated basic tests and docs.")
+
             # Return structure expected by manager
             result_tool = GeneratedTool(code=generated_code, tests=tests, docs=docs)
             return {
                 "status": "success",
-                "output": result_tool.model_dump()  # Serialize the GeneratedTool object
+                "output": result_tool.model_dump(),  # Serialize the GeneratedTool object
             }
 
         except (ValueError, CodeGenerationError) as e:
@@ -286,13 +362,14 @@ class ToolDesignerAgent(Agent): # Inherit from Agent
             logger.exception("Unexpected error in ToolDesignerAgent run")
             return {"status": "error", "error": f"Unexpected error: {e}"}
 
+
 # Example Usage (for interactive testing)
-if __name__ == '__main__':
+if __name__ == "__main__":
     import asyncio
     import os
-    
+
     # Example YAML spec
-    example_yaml_spec = '''
+    example_yaml_spec = """
     name: greet_user
     purpose: Greets the user by name.
     input_parameters:
@@ -301,15 +378,17 @@ if __name__ == '__main__':
         description: The name of the user to greet.
         required: true
     output_format: string
-    '''
+    """
 
     async def test_agent():
         # Get API key from environment variable (LLMService will also do this if not passed)
-        # api_key = os.environ.get("OPENAI_API_KEY") 
-        
+        # api_key = os.environ.get("OPENAI_API_KEY")
+
         # Create agent. LLMService will try to get API_KEY from env if not provided.
-        agent_template = ToolDesignerAgent() # For template-based
-        agent_llm = ToolDesignerAgent() # For LLM-based (will use env key or passed key)
+        agent_template = ToolDesignerAgent()  # For template-based
+        agent_llm = (
+            ToolDesignerAgent()
+        )  # For LLM-based (will use env key or passed key)
         # To test with an explicit key (e.g. if .env is not set or to override):
         # agent_llm_explicit_key = ToolDesignerAgent(llm_api_key="your_explicit_key_here")
 
@@ -324,17 +403,23 @@ if __name__ == '__main__':
             print(f"\n--- Error Designing Tool --- \n{e}")
 
         # Test LLM-based generation if available
-        if agent_llm.llm_code_generator: # Check if LLM components were successfully initialized
+        if (
+            agent_llm.llm_code_generator
+        ):  # Check if LLM components were successfully initialized
             try:
                 print("\n--- Designing Tool from YAML Spec (LLM-based) ---")
-                generated_code_llm = await agent_llm.design_tool_with_llm(example_yaml_spec)
+                generated_code_llm = await agent_llm.design_tool_with_llm(
+                    example_yaml_spec
+                )
                 print("\n--- Generated Code (LLM) --- \n")
                 print(generated_code_llm)
                 print("\n--- End Generated Code (LLM) ---")
             except (ValueError, CodeGenerationError, RuntimeError) as e:
                 print(f"\n--- Error Designing Tool with LLM --- \n{e}")
         else:
-            print("\n--- LLM-based generation not available (no API key found or error during init) ---")
+            print(
+                "\n--- LLM-based generation not available (no API key found or error during init) ---"
+            )
 
         # Example Invalid Spec
         invalid_spec = '{"name": "bad_tool"}'  # Missing purpose, output_format
@@ -346,5 +431,5 @@ if __name__ == '__main__':
             print(f"\n--- Error Designing Tool (Expected) --- \n{e}")
 
     # Run the async test
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         asyncio.run(test_agent())

--- a/src/meta_agent/generators/test_generator.py
+++ b/src/meta_agent/generators/test_generator.py
@@ -1,0 +1,35 @@
+"""Simple generator for basic unit tests of generated tools."""
+
+from meta_agent.parsers.tool_spec_parser import ToolSpecification
+
+
+def _example_value(param_type: str) -> str:
+    mapping = {
+        "int": "1",
+        "integer": "1",
+        "float": "1.0",
+        "string": "'test'",
+        "bool": "True",
+        "boolean": "True",
+        "list": "[]",
+        "dict": "{}",
+    }
+    return mapping.get(param_type.lower(), "None")
+
+
+def generate_basic_tests(spec: ToolSpecification) -> str:
+    """Generate minimal pytest code exercising the generated tool."""
+    param_assignments = []
+    for param in spec.input_parameters:
+        value = _example_value(param.type_)
+        param_assignments.append(f"{param.name}={value}")
+    args = ", ".join(param_assignments)
+    test_code = f"""
+import importlib
+
+def test_call():
+    mod = importlib.import_module('tool')
+    func = getattr(mod, '{spec.name}')
+    func({args})
+"""
+    return test_code

--- a/tests/generators/test_test_generator.py
+++ b/tests/generators/test_test_generator.py
@@ -1,0 +1,17 @@
+import ast
+from meta_agent.generators.test_generator import generate_basic_tests
+from meta_agent.parsers.tool_spec_parser import ToolSpecification, ToolParameter
+
+
+def test_generate_basic_tests():
+    spec = ToolSpecification(
+        name="greet",
+        purpose="Greets a user",
+        input_parameters=[ToolParameter(name="name", type_="string")],
+        output_format="string",
+    )
+    test_code = generate_basic_tests(spec)
+    assert "import importlib" in test_code
+    assert "greet" in test_code
+    # ensure code is syntactically valid
+    ast.parse(test_code)

--- a/tests/integration/test_tool_designer_agent.py
+++ b/tests/integration/test_tool_designer_agent.py
@@ -6,137 +6,184 @@ from meta_agent.agents.tool_designer_agent import ToolDesignerAgent
 from meta_agent.validation import validate_generated_tool
 from meta_agent.models.generated_tool import GeneratedTool
 
+
 @pytest.mark.asyncio
 async def test_golden_path_arithmetic():
     agent = ToolDesignerAgent()
     spec = {
-        'task_id': 'golden1',
-        'description': 'Create a function add(a: int, b: int) -> int that returns the sum.',
-        'name': 'add_numbers',
-        'purpose': 'Adds two numbers together',
-        'input_parameters': [
-            {'name': 'a', 'type': 'integer', 'description': 'First number', 'required': True},
-            {'name': 'b', 'type': 'integer', 'description': 'Second number', 'required': True}
+        "task_id": "golden1",
+        "description": "Create a function add(a: int, b: int) -> int that returns the sum.",
+        "name": "add_numbers",
+        "purpose": "Adds two numbers together",
+        "input_parameters": [
+            {
+                "name": "a",
+                "type": "integer",
+                "description": "First number",
+                "required": True,
+            },
+            {
+                "name": "b",
+                "type": "integer",
+                "description": "Second number",
+                "required": True,
+            },
         ],
-        'output_format': 'integer'
+        "output_format": "integer",
     }
     result = await agent.run(spec)
-    assert result['status'] == 'success', f"Tool generation failed: {result.get('error', 'Unknown error')}"
-    tool_data = result['output']
+    assert (
+        result["status"] == "success"
+    ), f"Tool generation failed: {result.get('error', 'Unknown error')}"
+    tool_data = result["output"]
     tool = GeneratedTool(**tool_data)
-    
-    # Skip validation as test generation is not fully implemented yet
-    pytest.skip("Skipping validation as test generation is not fully implemented yet")
-    
-    validation_result = validate_generated_tool(tool, tool_id='golden1')
+
+    validation_result = validate_generated_tool(tool, tool_id="golden1")
     assert validation_result.success, f"Validation failed: {validation_result.errors}"
     assert validation_result.coverage >= 0.9
+
 
 @pytest.mark.asyncio
 async def test_api_integration_openweathermap():
     agent = ToolDesignerAgent()
     spec = {
-        'task_id': 'api1',
-        'description': 'Create a tool that fetches the current weather for a city using the OpenWeatherMap API.',
-        'name': 'get_weather',
-        'purpose': 'Fetches current weather for a city',
-        'input_parameters': [
-            {'name': 'city', 'type': 'string', 'description': 'City name', 'required': True},
-            {'name': 'api_key', 'type': 'string', 'description': 'OpenWeatherMap API key', 'required': True}
+        "task_id": "api1",
+        "description": "Create a tool that fetches the current weather for a city using the OpenWeatherMap API.",
+        "name": "get_weather",
+        "purpose": "Fetches current weather for a city",
+        "input_parameters": [
+            {
+                "name": "city",
+                "type": "string",
+                "description": "City name",
+                "required": True,
+            },
+            {
+                "name": "api_key",
+                "type": "string",
+                "description": "OpenWeatherMap API key",
+                "required": True,
+            },
         ],
-        'output_format': 'dict'
+        "output_format": "dict",
     }
     result = await agent.run(spec)
-    assert result['status'] == 'success', f"Tool generation failed: {result.get('error', 'Unknown error')}"
-    tool_data = result['output']
+    assert (
+        result["status"] == "success"
+    ), f"Tool generation failed: {result.get('error', 'Unknown error')}"
+    tool_data = result["output"]
     tool = GeneratedTool(**tool_data)
-    
-    # Skip validation as test generation is not fully implemented yet
-    pytest.skip("Skipping validation as test generation is not fully implemented yet")
-    
+
     # Optionally mock requests if needed here
-    validation_result = validate_generated_tool(tool, tool_id='api1')
+    validation_result = validate_generated_tool(tool, tool_id="api1")
     assert validation_result.success, f"Validation failed: {validation_result.errors}"
     assert validation_result.coverage >= 0.9
+
 
 @pytest.mark.asyncio
 async def test_hosted_tool_search():
     # Skip this test for now as we need to refactor how we check for WebSearchTool
     pytest.skip("WebSearchTool import needs to be refactored")
-    
+
     agent = ToolDesignerAgent()
     spec = {
-        'task_id': 'hosted1',
-        'description': 'Search the web for a given query.',
-        'name': 'web_search',
-        'purpose': 'Searches the web for a query',
-        'input_parameters': [
-            {'name': 'query', 'type': 'string', 'description': 'Search query', 'required': True}
+        "task_id": "hosted1",
+        "description": "Search the web for a given query.",
+        "name": "web_search",
+        "purpose": "Searches the web for a query",
+        "input_parameters": [
+            {
+                "name": "query",
+                "type": "string",
+                "description": "Search query",
+                "required": True,
+            }
         ],
-        'output_format': 'list'
+        "output_format": "list",
     }
     result = await agent.run(spec)
-    assert result['status'] == 'success', f"Tool generation failed: {result.get('error', 'Unknown error')}"
-    tool_data = result['output']
+    assert (
+        result["status"] == "success"
+    ), f"Tool generation failed: {result.get('error', 'Unknown error')}"
+    tool_data = result["output"]
     tool = GeneratedTool(**tool_data)
-    assert 'WebSearchTool' in tool.code
-    validation_result = validate_generated_tool(tool, tool_id='hosted1')
+    assert "WebSearchTool" in tool.code
+    validation_result = validate_generated_tool(tool, tool_id="hosted1")
     assert validation_result.success, f"Validation failed: {validation_result.errors}"
+
 
 @pytest.mark.asyncio
 async def test_edge_case_invalid_type_annotations():
     agent = ToolDesignerAgent()
     spec = {
-        'task_id': 'edge1',
-        'description': 'Write a function that returns a list of numbers, but with intentionally confusing type annotations.',
-        'name': 'confusing_types',
-        'purpose': 'Returns a list with confusing type annotations',
-        'input_parameters': [
-            {'name': 'count', 'type': 'integer', 'description': 'Number of items', 'required': True}
+        "task_id": "edge1",
+        "description": "Write a function that returns a list of numbers, but with intentionally confusing type annotations.",
+        "name": "confusing_types",
+        "purpose": "Returns a list with confusing type annotations",
+        "input_parameters": [
+            {
+                "name": "count",
+                "type": "integer",
+                "description": "Number of items",
+                "required": True,
+            }
         ],
-        'output_format': 'list'
+        "output_format": "list",
     }
     result = await agent.run(spec)
-    assert result['status'] == 'success', f"Tool generation failed: {result.get('error', 'Unknown error')}"
-    tool_data = result['output']
+    assert (
+        result["status"] == "success"
+    ), f"Tool generation failed: {result.get('error', 'Unknown error')}"
+    tool_data = result["output"]
     tool = GeneratedTool(**tool_data)
-    
+
     # Keeping the existing skip for validation in this test
     pytest.skip("Skipping validation for edge case test")
-    
-    validation_result = validate_generated_tool(tool, tool_id='edge1')
+
+    validation_result = validate_generated_tool(tool, tool_id="edge1")
     assert validation_result.success, f"Validation failed: {validation_result.errors}"
     # Remove coverage assertion as validate_generated_tool handles edge case logic
     # assert validation_result.coverage >= 0.9
+
 
 @pytest.mark.asyncio
 async def test_performance_under_60s():
     agent = ToolDesignerAgent()
     spec = {
-        'task_id': 'perf1',
-        'description': 'Create a function multiply(a: int, b: int) -> int.',
-        'name': 'multiply',
-        'purpose': 'Multiplies two integers',
-        'input_parameters': [
-            {'name': 'a', 'type': 'integer', 'description': 'First number', 'required': True},
-            {'name': 'b', 'type': 'integer', 'description': 'Second number', 'required': True}
+        "task_id": "perf1",
+        "description": "Create a function multiply(a: int, b: int) -> int.",
+        "name": "multiply",
+        "purpose": "Multiplies two integers",
+        "input_parameters": [
+            {
+                "name": "a",
+                "type": "integer",
+                "description": "First number",
+                "required": True,
+            },
+            {
+                "name": "b",
+                "type": "integer",
+                "description": "Second number",
+                "required": True,
+            },
         ],
-        'output_format': 'integer'
+        "output_format": "integer",
     }
     start = time.time()
     result = await agent.run(spec)
     elapsed = time.time() - start
     assert elapsed <= 60, f"Generation took too long: {elapsed:.2f}s"
-    assert result['status'] == 'success', f"Tool generation failed: {result.get('error', 'Unknown error')}"
-    
-    # Skip validation as test generation is not fully implemented yet
-    pytest.skip("Skipping validation as test generation is not fully implemented yet")
-    
-    tool_data = result['output']
+    assert (
+        result["status"] == "success"
+    ), f"Tool generation failed: {result.get('error', 'Unknown error')}"
+
+    tool_data = result["output"]
     tool = GeneratedTool(**tool_data)
-    validation_result = validate_generated_tool(tool, tool_id='perf1')
+    validation_result = validate_generated_tool(tool, tool_id="perf1")
     assert validation_result.success, f"Validation failed: {validation_result.errors}"
     assert validation_result.coverage >= 0.9
+
 
 @pytest.mark.asyncio
 async def test_file_search_stub():
@@ -147,53 +194,66 @@ async def test_file_search_stub():
         "name": "file_search",
         "purpose": "Searches files for a term",
         "input_parameters": [
-            {"name": "term", "type": "string", "description": "Search term", "required": True},
-            {"name": "path", "type": "string", "description": "File path", "required": False}
+            {
+                "name": "term",
+                "type": "string",
+                "description": "Search term",
+                "required": True,
+            },
+            {
+                "name": "path",
+                "type": "string",
+                "description": "File path",
+                "required": False,
+            },
         ],
-        "output_format": "list"
+        "output_format": "list",
     }
     result = await agent.run(spec)
-    assert result['status'] == 'success', f"Tool generation failed: {result.get('error', 'Unknown error')}"
-    
-    # Skip validation as test generation is not fully implemented yet
-    pytest.skip("Skipping validation as test generation is not fully implemented yet")
-    
-    tool_data = result['output']
+    assert (
+        result["status"] == "success"
+    ), f"Tool generation failed: {result.get('error', 'Unknown error')}"
+
+    tool_data = result["output"]
     tool = GeneratedTool(**tool_data)
     validation_result = validate_generated_tool(tool, tool_id="files1")
     assert validation_result.success, f"Validation failed: {validation_result.errors}"
+
 
 @pytest.mark.asyncio
 async def test_invalid_json_from_llm():
     # Monkey-patch Runner.run to return non-JSON output
     from agents import Runner
+
     async def fake_run(*_, **__):
-        class FakeRes: final_output = "nonsense"
+        class FakeRes:
+            final_output = "nonsense"
+
         return FakeRes()
-    
+
     # Store original run method
-    orig = getattr(Runner, 'run', None)
-    
+    orig = getattr(Runner, "run", None)
+
     try:
         # Apply monkey patch if Runner.run exists
         if orig:
             Runner.run = fake_run
-            
+
         agent = ToolDesignerAgent()
         spec = {
-            "task_id": "badjson", 
+            "task_id": "badjson",
             "description": "add 1+1",
             "name": "add_one_plus_one",
             "purpose": "Adds 1+1",
             "input_parameters": [],
-            "output_format": "integer"
+            "output_format": "integer",
         }
         result = await agent.run(spec)
-        
+
         # Fixed assertion to match actual behavior - the agent is handling bad JSON gracefully
         # and still returning success status
-        assert result['status'] == 'success', "Should handle bad JSON gracefully"
-        assert 'output' in result, "Should include output even with bad JSON"
+        assert result["status"] == "success", "Should handle bad JSON gracefully"
+        assert "output" in result, "Should include output even with bad JSON"
     finally:
         # Restore original method if it existed
         if orig:


### PR DESCRIPTION
## Summary
- add basic test generation for designed tools
- generate docs from tool spec
- enable validation in integration tests
- test the new test generator

## Testing
- `ruff check src/meta_agent/generators/test_generator.py tests/generators/test_test_generator.py`
- `black --check src/meta_agent/generators/test_generator.py tests/generators/test_test_generator.py src/meta_agent/agents/tool_designer_agent.py tests/integration/test_tool_designer_agent.py`
- `mypy src/meta_agent/generators/test_generator.py src/meta_agent/agents/tool_designer_agent.py tests/generators/test_test_generator.py tests/integration/test_tool_designer_agent.py`
- `pyright`
- `pytest` *(failed: command not found)*