### PR TITLE
fix: ensure generated tools are loadable

### DIFF
--- a/src/meta_agent/sub_agent_manager.py
+++ b/src/meta_agent/sub_agent_manager.py
@@ -91,6 +91,7 @@ class CoderAgent(Agent):
 
 class TesterAgent(Agent):
     """Agent specialized for testing tasks."""
+
     __test__ = False  # Prevent pytest from collecting this as a test class
 
     def __init__(self):
@@ -328,10 +329,22 @@ def get_tool_instance():
             else:
                 generated_tool = None
 
-            if generated_tool is None:
-                logger.error(
-                    f"Tool designer failed to generate code for '{tool_name}'"
+            # The template-based designer may return code without a
+            # ``get_tool_instance`` factory.  If so, provide a basic fallback
+            # implementation to ensure the registry can load and execute it.
+            if generated_tool and "get_tool_instance" not in generated_tool.code:
+                logger.info(
+                    "Generated tool lacks 'get_tool_instance'; using basic fallback",
                 )
+                generated_tool = GeneratedTool(
+                    name=spec.get("name"),
+                    description=spec.get("description", ""),
+                    specification=spec.get("specification", {}),
+                    code=self._generate_basic_tool_code(spec.get("name", "Tool")),
+                )
+
+            if generated_tool is None:
+                logger.error(f"Tool designer failed to generate code for '{tool_name}'")
                 return None
 
             logger.info(f"Successfully generated code for tool '{tool_name}'")
@@ -349,7 +362,8 @@ def get_tool_instance():
                     code=self._generate_basic_tool_code(spec.get("name", "Tool")),
                 )
                 logger.info(
-                    f"Fallback tool generated for '{tool_name}'",)
+                    f"Fallback tool generated for '{tool_name}'",
+                )
             except Exception:
                 return None
 


### PR DESCRIPTION
## Summary
- add fallback to `_basic_tool_from_spec` when ToolDesigner code lacks `get_tool_instance`
- apply the same fallback in `SubAgentManager.create_tool`

## Testing
- `ruff check src/meta_agent/orchestrator.py src/meta_agent/sub_agent_manager.py`
- `black --check src/meta_agent/orchestrator.py src/meta_agent/sub_agent_manager.py`
- `mypy src/meta_agent/orchestrator.py src/meta_agent/sub_agent_manager.py` *(fails: "Cannot find implementation or library stub for module named 'jinja2'")*
- `pyright src/meta_agent/orchestrator.py src/meta_agent/sub_agent_manager.py` *(fails: "'Agent' is unknown import symbol")*
- `python -m pytest tests/integration/test_tool_lifecycle.py::test_end_to_end_tool_creation -vv` *(fails: No module named pytest)*