### PR TITLE
fix: return loaded module when class missing

### DIFF
--- a/src/meta_agent/registry.py
+++ b/src/meta_agent/registry.py
@@ -277,10 +277,10 @@ class ToolRegistry:
                 )
                 return tool_instance
             else:
-                logger.error(
-                    f"Tool class not found in module '{module_full_path}' for '{tool_name}'"
+                logger.warning(
+                    f"Tool class not found in module '{module_full_path}' for '{tool_name}'. Returning module instead."
                 )
-                return None
+                return tool_module
         except ImportError as e:
             logger.error(
                 f"Failed to import tool '{tool_name}' version '{actual_version_str}' from {module_full_path}: {e}"


### PR DESCRIPTION
## Summary
- improve `ToolRegistry.load` fallback logic so modules without a class are still returned

## Testing
- `ruff check .` *(fails: F401 etc.)*
- `black --check .` *(fails: would reformat many files)*
- `mypy .` *(fails: module imports missing)*
- `pyright` *(fails: various errors)*
- `python -m pytest -k test_tool_registry_lifecycle tests/test_e2e.py` *(fails: No module named pytest)*