### PR TITLE
feat: add guardrail model router

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "typeCheckingMode": "basic",
+  "reportMissingImports": false
+}

--- a/src/meta_agent/agents/guardrail_designer_agent.py
+++ b/src/meta_agent/agents/guardrail_designer_agent.py
@@ -1,0 +1,49 @@
+"""Prototype Guardrail Designer agent with model routing."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+
+class AgentBase:
+    """Minimal base class used when the Agents SDK is unavailable."""
+
+    def __init__(self, name: str | None = None, *_, **__):
+        self.name = name or "StubAgent"
+
+    async def run(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {"status": "error", "error": "agents SDK unavailable"}
+
+
+from meta_agent.services.guardrail_router import GuardrailModelRouter, LLMModelAdapter
+from meta_agent.services.llm_service import LLMService
+
+logger = logging.getLogger(__name__)
+
+
+class GuardrailDesignerAgent(AgentBase):
+    """Generates guardrail code using configurable model backends."""
+
+    def __init__(
+        self,
+        model_router: Optional[GuardrailModelRouter] = None,
+        *,
+        api_key: Optional[str] = None,
+        default_model: str = "gpt-4o",
+    ) -> None:
+        super().__init__(name="GuardrailDesignerAgent", tools=[])
+
+        if model_router is None:
+            service = LLMService(api_key=api_key, model=default_model)
+            adapter = LLMModelAdapter(service)
+            model_router = GuardrailModelRouter({default_model: adapter}, default_model)
+        self.model_router = model_router
+        self.default_model = default_model
+        logger.info("GuardrailDesignerAgent initialized with model %s", default_model)
+
+    async def run(self, specification: Dict[str, Any]) -> Dict[str, Any]:
+        prompt = specification.get("prompt") or specification.get("description", "")
+        model = specification.get("model", self.default_model)
+        result = await self.model_router.invoke(prompt, model=model)
+        return {"status": "success", "output": result}

--- a/src/meta_agent/services/__init__.py
+++ b/src/meta_agent/services/__init__.py
@@ -6,5 +6,6 @@ and provide functionality to other components of the meta_agent system.
 """
 
 from .llm_service import LLMService
+from .guardrail_router import GuardrailModelRouter, ModelAdapter, LLMModelAdapter
 
-__all__ = ["LLMService"]
+__all__ = ["LLMService", "GuardrailModelRouter", "ModelAdapter", "LLMModelAdapter"]

--- a/src/meta_agent/services/guardrail_router.py
+++ b/src/meta_agent/services/guardrail_router.py
@@ -1,0 +1,70 @@
+"""Routing layer that applies guardrails before hitting the underlying model."""
+
+from __future__ import annotations
+
+from typing import Protocol, Dict, Any, Callable, Awaitable, Optional, List
+
+from meta_agent.services.llm_service import LLMService
+
+
+class ModelAdapter(Protocol):
+    """Interface for model backends."""
+
+    async def invoke(
+        self, prompt: str, context: Optional[Dict[str, Any]] | None = None
+    ) -> str:
+        """Generate a response for the given prompt."""
+        ...
+
+
+class GuardrailModelRouter:
+    """Routes requests through guardrails to a selected model adapter."""
+
+    def __init__(self, adapters: Dict[str, ModelAdapter], default_model: str) -> None:
+        if not adapters:
+            raise ValueError("At least one model adapter must be provided")
+        if default_model not in adapters:
+            raise ValueError("Default model must exist in adapters")
+        self.adapters = adapters
+        self.default_model = default_model
+        self.input_guardrails: List[Callable[[str], Awaitable[None]]] = []
+        self.output_guardrails: List[Callable[[str], Awaitable[None]]] = []
+
+    def add_input_guardrail(self, guardrail: Callable[[str], Awaitable[None]]) -> None:
+        self.input_guardrails.append(guardrail)
+
+    def add_output_guardrail(self, guardrail: Callable[[str], Awaitable[None]]) -> None:
+        self.output_guardrails.append(guardrail)
+
+    async def invoke(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        for guard in self.input_guardrails:
+            await guard(prompt)
+
+        adapter = self.adapters.get(model or self.default_model)
+        if adapter is None:
+            raise ValueError(f"Unknown model '{model}'")
+
+        result = await adapter.invoke(prompt, context)
+
+        for guard in self.output_guardrails:
+            await guard(result)
+
+        return result
+
+
+class LLMModelAdapter:
+    """Simple adapter around :class:`LLMService`."""
+
+    def __init__(self, llm_service: LLMService) -> None:
+        self.llm_service = llm_service
+
+    async def invoke(
+        self, prompt: str, context: Optional[Dict[str, Any]] | None = None
+    ) -> str:
+        return await self.llm_service.generate_code(prompt, context or {})

--- a/tests/test_guardrail_designer_agent.py
+++ b/tests/test_guardrail_designer_agent.py
@@ -1,0 +1,21 @@
+import pytest
+
+from meta_agent.agents.guardrail_designer_agent import GuardrailDesignerAgent
+from meta_agent.services.guardrail_router import GuardrailModelRouter
+
+
+class DummyAdapter:
+    async def invoke(self, prompt: str, context=None) -> str:
+        return f"{prompt}:guarded"
+
+
+@pytest.mark.asyncio
+async def test_agent_routes_prompt_through_router():
+    adapter = DummyAdapter()
+    router = GuardrailModelRouter({"gpt": adapter}, default_model="gpt")
+    agent = GuardrailDesignerAgent(model_router=router)
+
+    result = await agent.run({"prompt": "hello"})
+
+    assert result["status"] == "success"
+    assert result["output"] == "hello:guarded"

--- a/tests/test_guardrail_router.py
+++ b/tests/test_guardrail_router.py
@@ -1,0 +1,46 @@
+import pytest
+
+from meta_agent.services.guardrail_router import GuardrailModelRouter
+
+
+class MockAdapter:
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    async def invoke(self, prompt: str, context=None) -> str:
+        self.prompts.append(prompt)
+        return f"{prompt}:ok"
+
+
+@pytest.mark.asyncio
+async def test_router_selects_model():
+    a1 = MockAdapter()
+    a2 = MockAdapter()
+    router = GuardrailModelRouter({"a": a1, "b": a2}, default_model="a")
+
+    res = await router.invoke("hi", model="b")
+
+    assert res == "hi:ok"
+    assert a2.prompts == ["hi"]
+    assert not a1.prompts
+
+
+@pytest.mark.asyncio
+async def test_guardrails_called_in_order():
+    adapter = MockAdapter()
+    router = GuardrailModelRouter({"a": adapter}, default_model="a")
+    order: list[str] = []
+
+    async def input_guardrail(prompt: str):
+        order.append(f"in:{prompt}")
+
+    async def output_guardrail(output: str):
+        order.append(f"out:{output}")
+
+    router.add_input_guardrail(input_guardrail)
+    router.add_output_guardrail(output_guardrail)
+
+    res = await router.invoke("test")
+
+    assert res == "test:ok"
+    assert order == ["in:test", "out:test:ok"]


### PR DESCRIPTION
## Summary
- implement GuardrailModelRouter service
- create GuardrailDesignerAgent prototype
- expose new services in package init
- add pyright config
- test router and designer agent

## Testing
- `ruff check src/meta_agent/services/guardrail_router.py src/meta_agent/agents/guardrail_designer_agent.py tests/test_guardrail_router.py tests/test_guardrail_designer_agent.py`
- `black --check src/meta_agent/agents/guardrail_designer_agent.py src/meta_agent/services/guardrail_router.py tests/test_guardrail_router.py tests/test_guardrail_designer_agent.py`
- `mypy --ignore-missing-imports src/meta_agent/services/guardrail_router.py src/meta_agent/agents/guardrail_designer_agent.py tests/test_guardrail_router.py tests/test_guardrail_designer_agent.py`
- `pyright src/meta_agent/services/guardrail_router.py src/meta_agent/agents/guardrail_designer_agent.py tests/test_guardrail_router.py tests/test_guardrail_designer_agent.py`
- `python -m pytest -v --cov=src/meta_agent tests/test_guardrail_router.py tests/test_guardrail_designer_agent.py` *(fails: No module named pytest)*