### PR TITLE
feat: add guardrail config models

### DIFF
--- a/src/meta_agent/generators/__init__.py
+++ b/src/meta_agent/generators/__init__.py
@@ -13,6 +13,12 @@ from .implementation_injector import ImplementationInjector
 from .fallback_manager import FallbackManager
 from .prompt_templates import PROMPT_TEMPLATES
 from .tool_code_generator import ToolCodeGenerator
+from .guardrail_generator import (
+    GuardrailAction,
+    GuardrailRule,
+    GuardrailConfig,
+    build_regex_guardrails,
+)
 
 __all__ = [
     # LLM-backed code generation components
@@ -25,5 +31,9 @@ __all__ = [
     "PROMPT_TEMPLATES",
     
     # Existing code generators
-    "ToolCodeGenerator"
+    "ToolCodeGenerator",
+    "GuardrailAction",
+    "GuardrailRule",
+    "GuardrailConfig",
+    "build_regex_guardrails",
 ]

--- a/src/meta_agent/generators/guardrail_generator.py
+++ b/src/meta_agent/generators/guardrail_generator.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Guardrail generation utilities using Pydantic models."""
+
+from enum import Enum
+import re
+from typing import Awaitable, Callable, List
+
+from pydantic import BaseModel, Field, field_validator, ValidationError
+
+
+class GuardrailAction(str, Enum):
+    """Supported actions when a guardrail is triggered."""
+
+    DENY = "deny"
+    REDACT = "redact"
+    FLAG = "flag"
+
+
+class GuardrailRule(BaseModel):
+    """Single guardrail rule based on a regex pattern."""
+
+    name: str = Field(..., description="Unique name of the guardrail rule")
+    pattern: str = Field(..., description="Regex pattern to evaluate")
+    action: GuardrailAction = Field(
+        default=GuardrailAction.DENY, description="Action taken on match"
+    )
+    description: str | None = None
+
+    @field_validator("pattern")
+    @classmethod
+    def validate_regex(cls, v: str) -> str:
+        try:
+            re.compile(v)
+        except re.error as exc:  # pragma: no cover - safety check
+            raise ValueError(f"Invalid regex pattern: {exc}") from exc
+        return v
+
+
+class GuardrailConfig(BaseModel):
+    """Collection of guardrail rules."""
+
+    rules: List[GuardrailRule] = Field(default_factory=list)
+
+    def add_rule(self, rule: GuardrailRule) -> None:
+        """Add a new rule to the configuration."""
+
+        self.rules.append(rule)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GuardrailConfig":
+        """Create a configuration from a dictionary."""
+
+        return cls(**data)
+
+
+def build_regex_guardrails(
+    config: GuardrailConfig,
+) -> List[Callable[[str], Awaitable[None]]]:
+    """Build async guardrail callables from a configuration."""
+
+    guards: List[Callable[[str], Awaitable[None]]] = []
+    for rule in config.rules:
+        pattern = re.compile(rule.pattern)
+
+        async def guard(value: str, *, _p=pattern, _r=rule) -> None:
+            if _p.search(value):
+                raise ValueError(f"Guardrail '{_r.name}' triggered")
+
+        guards.append(guard)
+    return guards
+

--- a/tests/test_guardrail_generator.py
+++ b/tests/test_guardrail_generator.py
@@ -1,0 +1,36 @@
+import pytest
+
+from meta_agent.generators.guardrail_generator import (
+    GuardrailAction,
+    GuardrailRule,
+    GuardrailConfig,
+    build_regex_guardrails,
+)
+
+
+def test_guardrail_rule_validation():
+    rule = GuardrailRule(name="no-secrets", pattern=r"secret")
+    assert rule.action is GuardrailAction.DENY
+
+    with pytest.raises(ValueError):
+        GuardrailRule(name="bad", pattern="(")
+
+
+def test_guardrail_config_add_rule():
+    config = GuardrailConfig()
+    rule = GuardrailRule(name="block", pattern="bad")
+    config.add_rule(rule)
+    assert config.rules == [rule]
+
+
+@pytest.mark.asyncio
+async def test_build_regex_guardrails_trigger():
+    config = GuardrailConfig(rules=[GuardrailRule(name="block", pattern="bad")])
+    guards = build_regex_guardrails(config)
+    assert len(guards) == 1
+    guard = guards[0]
+
+    await guard("good text")  # should not raise
+
+    with pytest.raises(ValueError):
+        await guard("this is bad")


### PR DESCRIPTION
## Summary
- implement guardrail generator with Pydantic models
- expose guardrail utilities in generator package
- test guardrail rule validation and runtime behaviour

## Testing
- `ruff check . | head`
- `black --check .`
- `pytest -q`
- `mypy src/meta_agent`
- `pyright`