### PR TITLE
test: expand guardrail coverage

### DIFF
--- a/tests/test_guardrail_designer_agent.py
+++ b/tests/test_guardrail_designer_agent.py
@@ -19,3 +19,10 @@ async def test_agent_routes_prompt_through_router():
 
     assert result["status"] == "success"
     assert result["output"] == "hello:guarded"
+
+
+def test_agent_creates_default_router(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    agent = GuardrailDesignerAgent()
+    assert isinstance(agent.model_router, GuardrailModelRouter)
+    assert agent.default_model == agent.model_router.default_model

--- a/tests/test_guardrail_generator.py
+++ b/tests/test_guardrail_generator.py
@@ -34,3 +34,30 @@ async def test_build_regex_guardrails_trigger():
 
     with pytest.raises(ValueError):
         await guard("this is bad")
+
+
+def test_guardrail_config_from_dict():
+    data = {"rules": [{"name": "pii", "pattern": "ssn"}]}
+    cfg = GuardrailConfig.from_dict(data)
+    assert len(cfg.rules) == 1
+    assert cfg.rules[0].name == "pii"
+
+
+@pytest.mark.asyncio
+async def test_build_regex_guardrails_multiple_rules():
+    cfg = GuardrailConfig(
+        rules=[
+            GuardrailRule(name="a", pattern="foo"),
+            GuardrailRule(name="b", pattern="bar"),
+        ]
+    )
+    guards = build_regex_guardrails(cfg)
+    assert len(guards) == 2
+
+    await guards[0]("nothing here")
+    await guards[1]("nothing here")
+
+    with pytest.raises(ValueError):
+        await guards[0]("foo")
+    with pytest.raises(ValueError):
+        await guards[1]("bar")


### PR DESCRIPTION
## Summary
- add failure case coverage for `GuardrailModelRouter`
- add more tests for guardrail generator helpers
- ensure `GuardrailDesignerAgent` creates a default router

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `mypy .` *(fails: found 28 errors)*
- `pyright` *(fails: 102 errors)*
- `pytest` *(fails: No module named 'pytest_asyncio')*