### PR TITLE
feat: add policy check utilities

### DIFF
--- a/src/meta_agent/policy.py
+++ b/src/meta_agent/policy.py
@@ -1,0 +1,75 @@
+"""Policy check utilities for guardrails.
+
+Provides an async ``PolicyChecker`` that evaluates text against
+configured rules and custom plugins.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Awaitable, Callable, List, Optional
+
+from meta_agent.generators.guardrail_generator import (
+    GuardrailAction,
+    GuardrailConfig,
+    GuardrailRule,
+)
+
+
+class PolicyChecker:
+    """Evaluate text against guardrail policy rules."""
+
+    def __init__(self, config: Optional[GuardrailConfig] = None) -> None:
+        self.checks: List[Callable[[str], Awaitable[str]]] = []
+        if config is not None:
+            self.add_from_config(config)
+
+    def add_from_config(self, config: GuardrailConfig) -> None:
+        """Add checks from a :class:`GuardrailConfig`."""
+
+        for rule in config.rules:
+            pattern = re.compile(rule.pattern)
+
+            def _make_check(
+                p: re.Pattern[str], r: GuardrailRule
+            ) -> Callable[[str], Awaitable[str]]:
+                if r.action is GuardrailAction.REDACT:
+
+                    async def _check(text: str) -> str:
+                        return p.sub("[REDACTED]", text)
+
+                else:  # DENY or FLAG -> raise error on match
+
+                    async def _check(text: str) -> str:
+                        if p.search(text):
+                            raise ValueError(f"Policy violation: {r.name}")
+                        return text
+
+                return _check
+
+            self.checks.append(_make_check(pattern, rule))
+
+    def add_check(self, check: Callable[[str], Awaitable[str]]) -> None:
+        """Register a custom check plugin."""
+
+        self.checks.append(check)
+
+    async def run(self, text: str) -> str:
+        """Run all checks sequentially and return possibly modified text."""
+
+        for check in self.checks:
+            text = await check(text)
+        return text
+
+
+async def build_policy_guardrails(
+    config: GuardrailConfig,
+) -> List[Callable[[str], Awaitable[None]]]:
+    """Helper to create router-compatible guardrails from a config."""
+
+    checker = PolicyChecker(config)
+
+    async def guard(text: str) -> None:
+        await checker.run(text)
+
+    return [guard]

--- a/tests/test_policy_checker.py
+++ b/tests/test_policy_checker.py
@@ -1,0 +1,47 @@
+import pytest
+
+from meta_agent.policy import PolicyChecker
+from meta_agent.generators.guardrail_generator import (
+    GuardrailConfig,
+    GuardrailRule,
+    GuardrailAction,
+)
+
+
+@pytest.mark.asyncio
+async def test_policy_checker_deny():
+    config = GuardrailConfig(rules=[GuardrailRule(name="block", pattern="bad")])
+    checker = PolicyChecker(config)
+
+    await checker.run("good text")  # should pass
+
+    with pytest.raises(ValueError):
+        await checker.run("bad text")
+
+
+@pytest.mark.asyncio
+async def test_policy_checker_redact():
+    config = GuardrailConfig(
+        rules=[
+            GuardrailRule(
+                name="secret", pattern="secret", action=GuardrailAction.REDACT
+            )
+        ]
+    )
+    checker = PolicyChecker(config)
+
+    result = await checker.run("my secret is here")
+    assert result == "my [REDACTED] is here"
+
+
+@pytest.mark.asyncio
+async def test_policy_checker_custom_plugin():
+    checker = PolicyChecker()
+
+    async def plugin(text: str) -> str:
+        return text.upper()
+
+    checker.add_check(plugin)
+
+    result = await checker.run("hello")
+    assert result == "HELLO"


### PR DESCRIPTION
## Summary
- add `PolicyChecker` class for runtime guardrail enforcement
- expose helper to build guardrail functions
- add unit tests for policy checks

## Testing
- `ruff check src/meta_agent/policy.py tests/test_policy_checker.py`
- `black --check src/meta_agent/policy.py tests/test_policy_checker.py`
- `mypy src/meta_agent/policy.py tests/test_policy_checker.py` *(fails: library stubs missing)*
- `pyright` *(fails: numerous type errors)*
- `pytest -v tests/test_policy_checker.py` *(fails: ModuleNotFoundError: 'pytest_asyncio')*