### PR TITLE
feat: add default regex guardrails

### DIFF
--- a/src/meta_agent/generators/__init__.py
+++ b/src/meta_agent/generators/__init__.py
@@ -19,21 +19,22 @@ from .guardrail_generator import (
     GuardrailConfig,
     build_regex_guardrails,
 )
+from .regex_patterns import build_default_regex_config
 
 __all__ = [
     # LLM-backed code generation components
     "LLMCodeGenerator",
-    "PromptBuilder", 
+    "PromptBuilder",
     "ContextBuilder",
     "CodeValidator",
     "ImplementationInjector",
     "FallbackManager",
     "PROMPT_TEMPLATES",
-    
     # Existing code generators
     "ToolCodeGenerator",
     "GuardrailAction",
     "GuardrailRule",
     "GuardrailConfig",
     "build_regex_guardrails",
+    "build_default_regex_config",
 ]

--- a/src/meta_agent/generators/regex_patterns.py
+++ b/src/meta_agent/generators/regex_patterns.py
@@ -1,0 +1,40 @@
+"""Default regex patterns for content filtering."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable
+
+from .guardrail_generator import GuardrailConfig, GuardrailRule
+
+# Predefined regex patterns for common sensitive data
+DEFAULT_REGEX_PATTERNS: Dict[str, str] = {
+    "email": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
+    "phone": r"\b(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b",
+    "ssn": r"\b\d{3}-\d{2}-\d{4}\b",
+    "credit_card": r"\b(?:\d[ -]*?){13,16}\b",
+    "password": r"(?i)password",
+}
+
+
+def build_default_regex_config(
+    additional_patterns: Dict[str, str] | None = None,
+) -> GuardrailConfig:
+    """Return a :class:`GuardrailConfig` with default regex rules.
+
+    Args:
+        additional_patterns: Optional extra name->pattern mappings to include.
+
+    Returns:
+        GuardrailConfig: Config populated with regex guardrail rules.
+    """
+    patterns: Dict[str, str] = {**DEFAULT_REGEX_PATTERNS}
+    if additional_patterns:
+        patterns.update(additional_patterns)
+
+    config = GuardrailConfig()
+    for name, pattern in patterns.items():
+        # validate pattern by compiling; GuardrailRule will also validate
+        re.compile(pattern)
+        config.add_rule(GuardrailRule(name=name, pattern=pattern))
+    return config

--- a/tests/test_regex_patterns.py
+++ b/tests/test_regex_patterns.py
@@ -1,0 +1,28 @@
+import re
+from meta_agent.generators.regex_patterns import (
+    DEFAULT_REGEX_PATTERNS,
+    build_default_regex_config,
+)
+from meta_agent.generators.guardrail_generator import GuardrailRule
+
+
+def test_default_patterns_match_samples():
+    samples = {
+        "email": "user@example.com",
+        "phone": "+1 555-123-4567",
+        "ssn": "123-45-6789",
+        "credit_card": "4111 1111 1111 1111",
+        "password": "my password is secret",
+    }
+    for name, pattern in DEFAULT_REGEX_PATTERNS.items():
+        assert re.search(pattern, samples[name])
+
+
+def test_build_default_regex_config():
+    config = build_default_regex_config()
+    rule_names = {rule.name for rule in config.rules}
+    assert set(DEFAULT_REGEX_PATTERNS.keys()) == rule_names
+    # ensure patterns are preserved
+    for rule in config.rules:
+        assert isinstance(rule, GuardrailRule)
+        assert DEFAULT_REGEX_PATTERNS[rule.name] == rule.pattern


### PR DESCRIPTION
## Summary
- implement default regex guardrail patterns and builder
- expose builder in generators package
- test default patterns and builder

## Testing
- `ruff check .` *(fails: F401, E401, F811, etc.)*
- `black --check .` *(fails: would reformat many files)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `mypy` *(fails: Missing target module, package, files, or command)*
- `pyright` *(fails: numerous errors)*