### PR TITLE
feat: integrate guardrail agent with agents sdk

### DIFF
--- a/tests/test_guardrail_designer_agent.py
+++ b/tests/test_guardrail_designer_agent.py
@@ -2,6 +2,7 @@ import pytest
 
 from meta_agent.agents.guardrail_designer_agent import GuardrailDesignerAgent
 from meta_agent.services.guardrail_router import GuardrailModelRouter
+import agents
 
 
 class DummyAdapter:
@@ -19,3 +20,10 @@ async def test_agent_routes_prompt_through_router():
 
     assert result["status"] == "success"
     assert result["output"] == "hello:guarded"
+
+
+def test_agent_inherits_from_agents():
+    router = GuardrailModelRouter({"gpt": DummyAdapter()}, default_model="gpt")
+    agent = GuardrailDesignerAgent(model_router=router)
+
+    assert isinstance(agent, agents.Agent)


### PR DESCRIPTION
## Summary
- integrate GuardrailDesignerAgent with the Agents SDK
- add unit test covering SDK integration

## Testing
- `ruff check .`
- `black --check .` *(fails: many files would be reformatted)*
- `pytest`
- `mypy src` *(fails: 46 errors)*
- `pyright` *(fails: 104 errors)*