### PR TITLE
docs: add guardrail designer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Generate production-ready agents in minutes, with built-in validation, sandboxin
 *   **Natural-language spec ingestion:** Accepts structured or free-form specifications describing goals, I/O contracts, tools, and constraints. This lowers the barrier to entry as there's no DSL to learn.
 *   **Agent planner (Meta Agent):** Decomposes the specification, orchestrates sub-agents, and assembles the final artifact. It acts as the central logic hub, enforcing consistency and versioning.
 *   **Tool Designer sub-agent:** Generates runnable Python code for each required tool and its unit tests, ensuring tools are functional from day one.
-*   **Guardrail Designer sub-agent:** Creates validation logic (Pydantic, regex, policy checks) and guardrail tests, embedding safety and compliance early to prevent bad outputs.
+*   **Guardrail Designer sub-agent:** Creates validation logic (Pydantic, regex, policy checks) and guardrail tests, embedding safety and compliance early to prevent bad outputs. See [docs/guardrail_designer_guide.md](docs/guardrail_designer_guide.md) for details.
 *   **Automated evaluation harness:** Compiles generated code, executes unit tests, and surfaces results, guaranteeing that the agent "actually runs."
 *   **Artifact bundle & dependency lock:** Outputs `agent.py`, `tests/`, `requirements.txt`, and an optional diagram. This allows for one-command install and run, ensuring reproducible builds.
 *   **Cost & trace telemetry:** Logs token usage, latency, and spend per generation, helping to manage cloud costs and aid optimization.

--- a/docs/guardrail_designer_guide.md
+++ b/docs/guardrail_designer_guide.md
@@ -1,0 +1,57 @@
+# Guardrail Designer Agent Guide
+
+This guide explains the Guardrail Designer Agent included in **Meta Agent**. The agent generates validation logic that protects both inputs and outputs of OpenAI Agents.
+
+## 1. Architecture
+
+The Guardrail Designer Agent sits between the Meta Agent orchestration layer and the underlying LLM model. It uses a `GuardrailModelRouter` to route prompts through user–defined guardrails before the model is invoked.
+
+```mermaid
+flowchart TD
+    U["User spec"] --> GDA["Guardrail Designer Agent"]
+    GDA --> R["GuardrailModelRouter"]
+    R --> M["LLM Model"]
+    subgraph Guardrails
+        IG[Input Guardrails]
+        OG[Output Guardrails]
+    end
+    R --> IG
+    R --> OG
+```
+
+## 2. Guardrail Logic
+
+Guardrails are declared using `GuardrailRule` objects and grouped in a `GuardrailConfig`. Rules rely on regular expressions and a configurable action such as **deny**, **redact** or **flag**. The helper `build_regex_guardrails` converts a configuration into async callables that can be attached to the router.
+
+## 3. Usage Example
+
+```python
+from meta_agent.agents.guardrail_designer_agent import GuardrailDesignerAgent
+from meta_agent.generators.regex_patterns import build_default_regex_config, build_regex_guardrails
+from meta_agent.services.guardrail_router import GuardrailModelRouter
+
+# Create guardrails from the default patterns and add a custom one
+config = build_default_regex_config({"custom": r"foo"})
+guards = build_regex_guardrails(config)
+
+router = GuardrailModelRouter({"gpt": DummyAdapter()}, default_model="gpt")
+for guard in guards:
+    router.add_input_guardrail(guard)
+
+agent = GuardrailDesignerAgent(model_router=router)
+result = await agent.run({"prompt": "hello"})
+```
+
+## 4. Configuration
+
+Use `build_default_regex_config()` to obtain a starting set of rules for e‑mail addresses, phone numbers and other sensitive patterns. Additional patterns can be supplied via the `additional_patterns` parameter.
+
+## 5. Extending the Guardrail System
+
+* Implement new `ModelAdapter` classes for other LLM services.
+* Register custom input or output guardrails with the router.
+* Combine guardrails with policy checks for advanced enforcement.
+
+## 6. Troubleshooting
+
+If guardrails raise unexpected errors, verify that the regex patterns compile correctly and that the router's model name matches a registered adapter. Detailed examples of the SDK can be found in `docs/openai_agents_sdk_docs.md`.


### PR DESCRIPTION
## Summary
- add guardrail designer guide covering architecture and usage
- link guardrail guide from README

## Testing
- `ruff check .`
- `black --check src/meta_agent tests` *(fails: many files would be reformatted)*
- `pytest -q` *(fails: pytest_asyncio missing)*
- `mypy src/meta_agent` *(fails: 47 errors)*
- `pyright` *(fails: 105 errors)*