### PR TITLE
docs: design evaluation harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Generate production-ready agents in minutes, with built-in validation, sandboxin
 *   **Agent planner (Meta Agent):** Decomposes the specification, orchestrates sub-agents, and assembles the final artifact. It acts as the central logic hub, enforcing consistency and versioning.
 *   **Tool Designer sub-agent:** Generates runnable Python code for each required tool and its unit tests, ensuring tools are functional from day one.
 *   **Guardrail Designer sub-agent:** Creates validation logic (Pydantic, regex, policy checks) and guardrail tests, embedding safety and compliance early to prevent bad outputs. See [docs/guardrail_designer_guide.md](docs/guardrail_designer_guide.md) for details.
-*   **Automated evaluation harness:** Compiles generated code, executes unit tests, and surfaces results, guaranteeing that the agent "actually runs."
+*   **Automated evaluation harness:** Compiles generated code, executes unit tests, and surfaces results, guaranteeing that the agent "actually runs." See [docs/evaluation_harness_architecture.md](docs/evaluation_harness_architecture.md) for the design.
 *   **Artifact bundle & dependency lock:** Outputs `agent.py`, `tests/`, `requirements.txt`, and an optional diagram. This allows for one-command install and run, ensuring reproducible builds.
 *   **Cost & trace telemetry:** Logs token usage, latency, and spend per generation, helping to manage cloud costs and aid optimization.
 

--- a/docs/evaluation_harness_architecture.md
+++ b/docs/evaluation_harness_architecture.md
@@ -1,0 +1,42 @@
+# Evaluation Harness Architecture
+
+## 1. Overview
+
+The evaluation harness verifies that generated agents compile and their unit
+tests run successfully inside a restricted sandbox. It is split into three
+modules so that execution, result collection and reporting remain decoupled.
+
+## 2. Modules
+
+### Execution Module
+- Runs pytest inside a Docker based sandbox via `SandboxManager`.
+- Enforces timeouts and resource limits.
+- Exposes `run_tests(path: Path) -> ExecutionResult`.
+
+### Result Collection Module
+- Gathers exit codes, stdout and stderr output.
+- Optionally collects coverage statistics and runtime metadata.
+- Provides a structured `ExecutionResult` dataclass.
+
+### Reporting Module
+- Formats results for CLI display or machine‑readable JSON/HTML.
+- Summarises pass/fail status and links to logs for debugging.
+
+### Harness Orchestrator
+- Coordinates the above modules and exposes a single `evaluate()` API.
+
+## 3. Diagram
+
+```mermaid
+flowchart TD
+    TG["Generated Code + Tests"] --> EXE
+    subgraph "Evaluation Harness"
+        EXE[Execution Module]
+        RC[Result Collection Module]
+        RP[Reporting Module]
+    end
+    EXE -->|"stdout, stderr"| RC
+    RC --> RP
+    RP --> OUT["Summary Report"]
+    EXE --> SM[SandboxManager]
+```


### PR DESCRIPTION
## Summary
- document the evaluation harness architecture
- reference the new document in the README

## Testing
- `ruff check .` *(fails: 172 errors)*
- `black --check .` *(fails: would reformat 74 files)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `mypy src/meta_agent` *(fails: 47 errors)*
- `pyright` *(fails: 105 errors, 8 warnings)*
