### PR TITLE
feat: add execution module

### DIFF
--- a/src/meta_agent/evaluation/__init__.py
+++ b/src/meta_agent/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Evaluation harness modules."""
+
+from .execution import ExecutionModule, ExecutionResult
+
+__all__ = ["ExecutionModule", "ExecutionResult"]

--- a/src/meta_agent/evaluation/execution.py
+++ b/src/meta_agent/evaluation/execution.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from meta_agent.sandbox.sandbox_manager import SandboxManager
+
+
+@dataclass
+class ExecutionResult:
+    """Result of running tests inside the sandbox."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class ExecutionModule:
+    """Run pytest for generated code inside a Docker sandbox."""
+
+    def __init__(self, sandbox_manager: Optional[SandboxManager] = None) -> None:
+        self.sandbox_manager = sandbox_manager or SandboxManager()
+
+    def run_tests(self, path: Path, timeout: int = 60) -> ExecutionResult:
+        """Execute tests located at ``path`` inside the sandbox."""
+        exit_code, stdout, stderr = self.sandbox_manager.run_code_in_sandbox(
+            code_directory=path,
+            command=["pytest", "-vv"],
+            timeout=timeout,
+        )
+        return ExecutionResult(exit_code=exit_code, stdout=stdout, stderr=stderr)

--- a/tests/unit/test_execution_module.py
+++ b/tests/unit/test_execution_module.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import MagicMock
+
+import meta_agent.evaluation.execution as exec_mod
+from meta_agent.evaluation.execution import ExecutionModule, ExecutionResult
+
+
+def test_init_creates_manager(monkeypatch):
+    fake_cls = MagicMock()
+    fake_instance = MagicMock()
+    fake_cls.return_value = fake_instance
+    monkeypatch.setattr(exec_mod, "SandboxManager", fake_cls)
+    module = ExecutionModule()
+    assert module.sandbox_manager is fake_instance
+
+
+def test_run_tests_success(monkeypatch, tmp_path):
+    fake_manager = MagicMock()
+    fake_manager.run_code_in_sandbox.return_value = (0, "out", "err")
+    module = ExecutionModule(fake_manager)
+    result = module.run_tests(tmp_path, timeout=5)
+    assert isinstance(result, ExecutionResult)
+    assert result.exit_code == 0
+    assert result.stdout == "out"
+    assert result.stderr == "err"
+    fake_manager.run_code_in_sandbox.assert_called_with(
+        code_directory=tmp_path,
+        command=["pytest", "-vv"],
+        timeout=5,
+    )
+
+
+def test_run_tests_propagates_error(monkeypatch, tmp_path):
+    fake_manager = MagicMock()
+    fake_manager.run_code_in_sandbox.side_effect = exec_mod.SandboxExecutionError(
+        "boom"
+    )
+    module = ExecutionModule(fake_manager)
+    with pytest.raises(exec_mod.SandboxExecutionError):
+        module.run_tests(tmp_path)


### PR DESCRIPTION
## Summary
- add execution module for running tests in sandbox
- expose execution module in evaluation package
- cover execution module with unit tests

## Testing
- `ruff check .` *(fails: multiple style violations)*
- `black --check .` *(fails: would reformat many files)*
- `mypy src/meta_agent` *(fails: missing stubs and type errors)*
- `pyright` *(fails: numerous type issues)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*