### PR TITLE
feat: add result collection module

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,2 +1,2 @@
-exclude = ["AGENTS.md"]
+exclude = ["AGENTS.md", "src/.tool_designer/**"]
 force-exclude = true

--- a/src/meta_agent/evaluation/__init__.py
+++ b/src/meta_agent/evaluation/__init__.py
@@ -1,5 +1,11 @@
 """Evaluation harness modules."""
 
 from .execution import ExecutionModule, ExecutionResult
+from .result_collection import CollectionResult, ResultCollectionModule
 
-__all__ = ["ExecutionModule", "ExecutionResult"]
+__all__ = [
+    "ExecutionModule",
+    "ExecutionResult",
+    "ResultCollectionModule",
+    "CollectionResult",
+]

--- a/src/meta_agent/evaluation/result_collection.py
+++ b/src/meta_agent/evaluation/result_collection.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+import time
+
+from meta_agent.evaluation.execution import ExecutionModule
+from meta_agent.sandbox.sandbox_manager import SandboxExecutionError  # noqa: F401
+
+
+@dataclass
+class CollectionResult:
+    """Execution results with timing metadata."""
+
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration: float
+
+
+class ResultCollectionModule:
+    """Collect results from the :class:`ExecutionModule`."""
+
+    def __init__(self, execution_module: Optional[ExecutionModule] = None) -> None:
+        self.execution_module = execution_module or ExecutionModule()
+
+    def execute_and_collect(self, path: Path, timeout: int = 60) -> CollectionResult:
+        """Run tests via the execution module and gather outputs."""
+        start = time.perf_counter()
+        result = self.execution_module.run_tests(path, timeout)
+        end = time.perf_counter()
+        return CollectionResult(
+            exit_code=result.exit_code,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            duration=end - start,
+        )

--- a/tests/unit/test_result_collection_module.py
+++ b/tests/unit/test_result_collection_module.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+import pytest
+
+from meta_agent.evaluation.result_collection import (
+    ResultCollectionModule,
+    CollectionResult,
+)
+from meta_agent.evaluation.execution import ExecutionResult
+import meta_agent.evaluation.result_collection as rc_mod
+
+
+def test_init_creates_execution_module(monkeypatch):
+    fake_cls = MagicMock()
+    fake_instance = MagicMock()
+    fake_cls.return_value = fake_instance
+    monkeypatch.setattr(rc_mod, "ExecutionModule", fake_cls)
+    module = ResultCollectionModule()
+    assert module.execution_module is fake_instance
+
+
+def test_execute_and_collect_success(monkeypatch, tmp_path):
+    fake_exec = MagicMock()
+    fake_exec.run_tests.return_value = ExecutionResult(0, "out", "err")
+    module = ResultCollectionModule(fake_exec)
+    result = module.execute_and_collect(tmp_path, timeout=5)
+    assert isinstance(result, CollectionResult)
+    assert result.exit_code == 0
+    assert result.stdout == "out"
+    assert result.stderr == "err"
+    assert result.duration >= 0
+    fake_exec.run_tests.assert_called_with(tmp_path, timeout=5)
+
+
+def test_execute_and_collect_propagates_error(monkeypatch, tmp_path):
+    fake_exec = MagicMock()
+    fake_exec.run_tests.side_effect = rc_mod.SandboxExecutionError("boom")
+    module = ResultCollectionModule(fake_exec)
+    with pytest.raises(rc_mod.SandboxExecutionError):
+        module.execute_and_collect(tmp_path)


### PR DESCRIPTION
## Summary
- add CollectionResult and ResultCollectionModule for evaluation
- expose new module in evaluation package
- cover module with unit tests
- ignore `.tool_designer` artefacts in ruff config

## Testing
- `ruff check src/meta_agent/evaluation/result_collection.py tests/unit/test_result_collection_module.py`
- `black --check src/meta_agent/evaluation/result_collection.py tests/unit/test_result_collection_module.py`
- `mypy src/meta_agent/evaluation/result_collection.py tests/unit/test_result_collection_module.py` *(fails: Library stubs not installed for `docker`)*
- `pyright src/meta_agent/evaluation/result_collection.py tests/unit/test_result_collection_module.py`
- `pytest -q tests/unit/test_result_collection_module.py` *(fails: No module named 'pytest_asyncio')*