### PR TITLE
feat: add reporting module

### DIFF
--- a/src/meta_agent/evaluation/__init__.py
+++ b/src/meta_agent/evaluation/__init__.py
@@ -2,10 +2,13 @@
 
 from .execution import ExecutionModule, ExecutionResult
 from .result_collection import CollectionResult, ResultCollectionModule
+from .reporting import ReportingModule, SummaryReport
 
 __all__ = [
     "ExecutionModule",
     "ExecutionResult",
     "ResultCollectionModule",
     "CollectionResult",
+    "ReportingModule",
+    "SummaryReport",
 ]

--- a/src/meta_agent/evaluation/reporting.py
+++ b/src/meta_agent/evaluation/reporting.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import html
+import json
+from typing import Iterable, List
+
+from meta_agent.evaluation.result_collection import CollectionResult
+
+
+@dataclass
+class SummaryReport:
+    """Summarised information about a collection result."""
+
+    exit_code: int
+    passed: bool
+    duration: float
+    stdout: str
+    stderr: str
+
+
+class ReportingModule:
+    """Format :class:`CollectionResult` objects for display."""
+
+    def summarize(self, result: CollectionResult) -> SummaryReport:
+        """Create a :class:`SummaryReport` from a collection result."""
+        return SummaryReport(
+            exit_code=result.exit_code,
+            passed=result.exit_code == 0,
+            duration=result.duration,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    def aggregate(self, results: Iterable[CollectionResult]) -> List[SummaryReport]:
+        """Summarize multiple results."""
+        return [self.summarize(r) for r in results]
+
+    def to_text(self, report: SummaryReport) -> str:
+        """Return a human‑readable text report."""
+        lines = [
+            f"Status: {'PASSED' if report.passed else 'FAILED'}",
+            f"Exit Code: {report.exit_code}",
+            f"Duration: {report.duration:.2f}s",
+            "stdout:\n" + report.stdout,
+            "stderr:\n" + report.stderr,
+        ]
+        return "\n".join(lines)
+
+    def to_json(self, report: SummaryReport) -> str:
+        """Return a JSON representation of the report."""
+        return json.dumps(asdict(report), indent=2)
+
+    def to_html(self, report: SummaryReport) -> str:
+        """Return a simple HTML representation of the report."""
+        return (
+            "<html><body>"
+            "<h2>Evaluation Report</h2>"
+            f"<p>Status: {'PASSED' if report.passed else 'FAILED'}</p>"
+            f"<p>Exit Code: {report.exit_code}</p>"
+            f"<p>Duration: {report.duration:.2f}s</p>"
+            f"<h3>stdout</h3><pre>{html.escape(report.stdout)}</pre>"
+            f"<h3>stderr</h3><pre>{html.escape(report.stderr)}</pre>"
+            "</body></html>"
+        )
+
+    def generate_report(self, result: CollectionResult, output_format: str = "text") -> str:
+        """Generate a formatted report for a result."""
+        summary = self.summarize(result)
+        if output_format == "json":
+            return self.to_json(summary)
+        if output_format == "html":
+            return self.to_html(summary)
+        return self.to_text(summary)

--- a/tests/unit/test_reporting_module.py
+++ b/tests/unit/test_reporting_module.py
@@ -1,0 +1,35 @@
+from meta_agent.evaluation.reporting import ReportingModule, SummaryReport
+from meta_agent.evaluation.result_collection import CollectionResult
+
+
+def make_result(exit_code: int = 0) -> CollectionResult:
+    return CollectionResult(exit_code=exit_code, stdout="out", stderr="err", duration=1.23)
+
+
+def test_summarize_creates_report():
+    module = ReportingModule()
+    result = make_result()
+    report = module.summarize(result)
+    assert isinstance(report, SummaryReport)
+    assert report.exit_code == 0
+    assert report.passed is True
+    assert report.duration == 1.23
+    assert report.stdout == "out"
+    assert report.stderr == "err"
+
+
+def test_generate_json_report():
+    module = ReportingModule()
+    result = make_result(exit_code=1)
+    json_report = module.generate_report(result, output_format="json")
+    assert "\"exit_code\": 1" in json_report
+    assert "\"passed\": false" in json_report
+
+
+def test_generate_html_report():
+    module = ReportingModule()
+    result = make_result()
+    html_report = module.generate_report(result, output_format="html")
+    assert html_report.startswith("<html>")
+    assert "PASSED" in html_report
+


### PR DESCRIPTION
## Summary
- implement evaluation reporting module
- expose reporting tools in evaluation package
- test reporting module

## Testing
- `ruff check .` *(fails: Found 37 errors)*
- `black --check .` *(fails: 76 files would be reformatted)*
- `mypy src/meta_agent` *(fails: found 44 errors)*
- `pyright` *(fails: 91 errors, 7 warnings)*
- `pytest -q` *(fails: ImportError: No module named 'pytest_asyncio')*