### PR TITLE
feat: add logging across evaluation modules

### DIFF
--- a/src/meta_agent/evaluation/execution.py
+++ b/src/meta_agent/evaluation/execution.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from meta_agent.sandbox.sandbox_manager import SandboxManager, SandboxExecutionError
+import logging
+
+from meta_agent.sandbox.sandbox_manager import (
+    SandboxExecutionError,
+    SandboxManager,
+)
 
 
 @dataclass
@@ -19,12 +24,19 @@ class ExecutionModule:
 
     def __init__(self, sandbox_manager: Optional[SandboxManager] = None) -> None:
         self.sandbox_manager = sandbox_manager or SandboxManager()
+        self.logger = logging.getLogger(__name__)
 
     def run_tests(self, path: Path, timeout: int = 60) -> ExecutionResult:
         """Execute tests located at ``path`` inside the sandbox."""
-        exit_code, stdout, stderr = self.sandbox_manager.run_code_in_sandbox(
-            code_directory=path,
-            command=["pytest", "-vv"],
-            timeout=timeout,
-        )
+        self.logger.info("Running tests in %s", path)
+        try:
+            exit_code, stdout, stderr = self.sandbox_manager.run_code_in_sandbox(
+                code_directory=path,
+                command=["pytest", "-vv"],
+                timeout=timeout,
+            )
+            self.logger.debug("Sandbox returned exit code %s", exit_code)
+        except SandboxExecutionError:
+            self.logger.error("Sandbox execution failed", exc_info=True)
+            raise
         return ExecutionResult(exit_code=exit_code, stdout=stdout, stderr=stderr)

--- a/src/meta_agent/evaluation/reporting.py
+++ b/src/meta_agent/evaluation/reporting.py
@@ -5,6 +5,8 @@ import html
 import json
 from typing import Iterable, List
 
+import logging
+
 from meta_agent.evaluation.result_collection import CollectionResult
 
 
@@ -22,8 +24,12 @@ class SummaryReport:
 class ReportingModule:
     """Format :class:`CollectionResult` objects for display."""
 
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__)
+
     def summarize(self, result: CollectionResult) -> SummaryReport:
         """Create a :class:`SummaryReport` from a collection result."""
+        self.logger.debug("Summarizing result with exit code %s", result.exit_code)
         return SummaryReport(
             exit_code=result.exit_code,
             passed=result.exit_code == 0,
@@ -34,7 +40,9 @@ class ReportingModule:
 
     def aggregate(self, results: Iterable[CollectionResult]) -> List[SummaryReport]:
         """Summarize multiple results."""
-        return [self.summarize(r) for r in results]
+        result_list = list(results)
+        self.logger.debug("Aggregating %d results", len(result_list))
+        return [self.summarize(r) for r in result_list]
 
     def to_text(self, report: SummaryReport) -> str:
         """Return a human‑readable text report."""
@@ -64,8 +72,11 @@ class ReportingModule:
             "</body></html>"
         )
 
-    def generate_report(self, result: CollectionResult, output_format: str = "text") -> str:
+    def generate_report(
+        self, result: CollectionResult, output_format: str = "text"
+    ) -> str:
         """Generate a formatted report for a result."""
+        self.logger.info("Generating %s report", output_format)
         summary = self.summarize(result)
         if output_format == "json":
             return self.to_json(summary)

--- a/src/meta_agent/evaluation/result_collection.py
+++ b/src/meta_agent/evaluation/result_collection.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Optional
 import time
 
+import logging
+
 from meta_agent.evaluation.execution import ExecutionModule
 from meta_agent.sandbox.sandbox_manager import SandboxExecutionError  # noqa: F401
 
@@ -24,12 +26,19 @@ class ResultCollectionModule:
 
     def __init__(self, execution_module: Optional[ExecutionModule] = None) -> None:
         self.execution_module = execution_module or ExecutionModule()
+        self.logger = logging.getLogger(__name__)
 
     def execute_and_collect(self, path: Path, timeout: int = 60) -> CollectionResult:
         """Run tests via the execution module and gather outputs."""
+        self.logger.info("Executing and collecting results for %s", path)
         start = time.perf_counter()
         result = self.execution_module.run_tests(path, timeout=timeout)
         end = time.perf_counter()
+        self.logger.debug(
+            "Execution finished in %.2fs with exit code %s",
+            end - start,
+            result.exit_code,
+        )
         return CollectionResult(
             exit_code=result.exit_code,
             stdout=result.stdout,

--- a/src/meta_agent/sandbox/sandbox_manager.py
+++ b/src/meta_agent/sandbox/sandbox_manager.py
@@ -1,6 +1,7 @@
 import docker
 import os
 import json
+import logging
 from pathlib import Path
 from typing import Tuple
 
@@ -8,16 +9,21 @@ from typing import Tuple
 _current_dir = Path(__file__).parent.resolve()
 # Construct the path to seccomp.json relative to the project root
 _project_root = _current_dir.parent.parent.parent
-_seccomp_profile_path = _project_root / 'seccomp.json'
+_seccomp_profile_path = _project_root / "seccomp.json"
 
 DEFAULT_IMAGE_NAME = "meta-agent-sandbox:latest"
 DEFAULT_TIMEOUT_SECONDS = 60
 DEFAULT_MEM_LIMIT = "256m"
-DEFAULT_CPU_SHARES = 512 # Relative weight, 1024 is default
+DEFAULT_CPU_SHARES = 512  # Relative weight, 1024 is default
+
+logger = logging.getLogger(__name__)
+
 
 class SandboxExecutionError(Exception):
     """Custom exception for sandbox execution errors."""
+
     pass
+
 
 class SandboxManager:
     """Manages the execution of code within a secure Docker sandbox."""
@@ -27,40 +33,47 @@ class SandboxManager:
             self.client = docker.from_env()
             # Ping the Docker daemon to ensure connection
             self.client.ping()
-            print("Successfully connected to Docker daemon.")
+            logger.info("Successfully connected to Docker daemon.")
         except docker.errors.DockerException as e:
-            print(f"Error connecting to Docker daemon: {e}")
-            print("Please ensure Docker is running and accessible.")
+            logger.error("Error connecting to Docker daemon: %s", e)
+            logger.error("Please ensure Docker is running and accessible.")
             # Depending on use case, might raise or handle differently
             raise ConnectionError("Could not connect to Docker daemon.") from e
-        
+
         self._load_seccomp_profile()
 
     def _load_seccomp_profile(self):
         """Loads the seccomp profile from the JSON file."""
         try:
-            with open(_seccomp_profile_path, 'r') as f:
+            with open(_seccomp_profile_path, "r") as f:
                 self.seccomp_profile = json.load(f)
-            print(f"Successfully loaded seccomp profile from {_seccomp_profile_path}")
+            logger.info(
+                "Successfully loaded seccomp profile from %s", _seccomp_profile_path
+            )
         except FileNotFoundError:
-            print(f"Warning: Seccomp profile not found at {_seccomp_profile_path}. Running without seccomp.")
+            logger.warning(
+                "Seccomp profile not found at %s. Running without seccomp.",
+                _seccomp_profile_path,
+            )
             self.seccomp_profile = None
         except json.JSONDecodeError as e:
-            print(f"Error decoding seccomp profile JSON: {e}")
+            logger.error("Error decoding seccomp profile JSON: %s", e)
             self.seccomp_profile = None
             # Optionally raise an error if seccomp is critical
             # raise ValueError("Invalid seccomp profile JSON") from e
 
-    def run_code_in_sandbox(self,
-                              code_directory: Path,
-                              command: list[str],
-                              image_name: str = DEFAULT_IMAGE_NAME,
-                              timeout: int = DEFAULT_TIMEOUT_SECONDS,
-                              mem_limit: str = DEFAULT_MEM_LIMIT,
-                              cpu_shares: int = DEFAULT_CPU_SHARES,
-                              network_disabled: bool = True) -> Tuple[int, str, str]: 
+    def run_code_in_sandbox(
+        self,
+        code_directory: Path,
+        command: list[str],
+        image_name: str = DEFAULT_IMAGE_NAME,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+        mem_limit: str = DEFAULT_MEM_LIMIT,
+        cpu_shares: int = DEFAULT_CPU_SHARES,
+        network_disabled: bool = True,
+    ) -> Tuple[int, str, str]:
         """Runs the given command inside a Docker container sandbox.
-        
+
         Args:
             code_directory: Path to the directory containing the code to be mounted.
             command: The command and arguments to run inside the container (e.g., ['python', 'agent.py']).
@@ -69,10 +82,10 @@ class SandboxManager:
             mem_limit: Memory limit for the container (e.g., '256m').
             cpu_shares: Relative CPU shares (weight).
             network_disabled: Whether to disable networking for the container.
-        
+
         Returns:
             A tuple containing the exit code, stdout, and stderr.
-            
+
         Raises:
             SandboxExecutionError: If there's an error running the container or execution times out.
             FileNotFoundError: If the code_directory doesn't exist.
@@ -81,18 +94,21 @@ class SandboxManager:
             raise FileNotFoundError(f"Code directory not found: {code_directory}")
 
         container_name = f"meta-agent-sandbox-run-{os.urandom(4).hex()}"
-        
+
         volumes = {
-            str(code_directory.resolve()): {'bind': '/sandbox/code', 'mode': 'ro'} # Mount code read-only
+            str(code_directory.resolve()): {
+                "bind": "/sandbox/code",
+                "mode": "ro",
+            }  # Mount code read-only
         }
-        
+
         security_opts = []
         if self.seccomp_profile:
             # Docker SDK expects the profile as a string, not a dict
             security_opts.append(f"seccomp={json.dumps(self.seccomp_profile)}")
 
         environment = {
-            'OPENBLAS_NUM_THREADS': '1',
+            "OPENBLAS_NUM_THREADS": "1",
             # Add other necessary environment variables here
         }
 
@@ -100,113 +116,130 @@ class SandboxManager:
 
         container = None
         try:
-            print(f"Running command {' '.join(command)} in sandbox ({image_name})...")
+            logger.info(
+                "Running command %s in sandbox (%s)...", " ".join(command), image_name
+            )
             container = self.client.containers.run(
                 image=image_name,
                 command=command,
                 volumes=volumes,
-                working_dir="/sandbox/code", # Run command relative to mounted code
+                working_dir="/sandbox/code",  # Run command relative to mounted code
                 mem_limit=mem_limit,
-                cpu_shares=cpu_shares, # Note: This is relative weight, not a hard limit
+                cpu_shares=cpu_shares,  # Note: This is relative weight, not a hard limit
                 # TODO: Consider cpus or cpuset_cpus for hard limits if needed
-                pids_limit=100, # Limit number of processes - added based on OpenBLAS error
+                pids_limit=100,  # Limit number of processes - added based on OpenBLAS error
                 security_opt=security_opts,
                 network_disabled=network_disabled,
-                environment=environment, # Pass environment variables
-                detach=True, # Run in background to manage timeout
-                remove=False, # Keep container for log retrieval, remove manually
-                user="sandboxuser", # Run as non-root user defined in Dockerfile
-                read_only=False, # Filesystem needs some writability for Python caches etc.
-                                 # Code mount is read-only via volumes
-                # TODO: Define specific writable tmpfs if stricter isolation needed: tmpfs={'/tmp': ''} 
-                name=container_name
+                environment=environment,  # Pass environment variables
+                detach=True,  # Run in background to manage timeout
+                remove=False,  # Keep container for log retrieval, remove manually
+                user="sandboxuser",  # Run as non-root user defined in Dockerfile
+                read_only=False,  # Filesystem needs some writability for Python caches etc.
+                # Code mount is read-only via volumes
+                # TODO: Define specific writable tmpfs if stricter isolation needed: tmpfs={'/tmp': ''}
+                name=container_name,
             )
 
             # Wait for container completion with timeout
             try:
                 result = container.wait(timeout=timeout)
-                exit_code = result.get('StatusCode', -1)
-            except Exception as e: # Catches requests.exceptions.ReadTimeout and others
-                print(f"Execution timed out after {timeout} seconds.")
+                exit_code = result.get("StatusCode", -1)
+            except Exception as e:  # Catches requests.exceptions.ReadTimeout and others
+                logger.error("Execution timed out after %s seconds.", timeout)
                 # Ensure container is stopped and removed on timeout
                 try:
                     container.stop(timeout=5)
                 except docker.errors.APIError as stop_err:
-                    print(f"Warning: Error stopping timed-out container: {stop_err}")
+                    logger.warning("Error stopping timed-out container: %s", stop_err)
                 try:
                     container.remove(force=True)
                 except docker.errors.APIError as remove_err:
-                    print(f"Warning: Error removing timed-out container: {remove_err}")
-                raise SandboxExecutionError(f"Execution timed out after {timeout} seconds") from e
+                    logger.warning("Error removing timed-out container: %s", remove_err)
+                raise SandboxExecutionError(
+                    f"Execution timed out after {timeout} seconds"
+                ) from e
 
             # Retrieve logs (stdout/stderr)
-            stdout = container.logs(stdout=True, stderr=False).decode('utf-8', errors='replace')
-            stderr = container.logs(stdout=False, stderr=True).decode('utf-8', errors='replace')
+            stdout = container.logs(stdout=True, stderr=False).decode(
+                "utf-8", errors="replace"
+            )
+            stderr = container.logs(stdout=False, stderr=True).decode(
+                "utf-8", errors="replace"
+            )
 
-            print(f"Sandbox execution finished with exit code: {exit_code}")
+            logger.info("Sandbox execution finished with exit code: %s", exit_code)
             return exit_code, stdout, stderr
 
         except docker.errors.ImageNotFound:
-            print(f"Error: Docker image '{image_name}' not found.")
-            raise SandboxExecutionError(f"Sandbox image '{image_name}' not found. Please build it first.")
+            logger.error("Docker image '%s' not found.", image_name)
+            raise SandboxExecutionError(
+                f"Sandbox image '{image_name}' not found. Please build it first."
+            )
         except docker.errors.APIError as e:
-            print(f"Error running Docker container: {e}")
+            logger.error("Error running Docker container: %s", e)
             raise SandboxExecutionError(f"Failed to run sandbox container: {e}") from e
         finally:
             # Ensure container is removed after execution
             if container:
                 try:
-                    container.remove(force=True) # Force remove in case it's stuck
-                    print(f"Removed container: {container_name}")
+                    container.remove(force=True)  # Force remove in case it's stuck
+                    logger.info("Removed container: %s", container_name)
                 except docker.errors.NotFound:
-                    pass # Container already removed (e.g., on timeout)
+                    pass  # Container already removed (e.g., on timeout)
                 except docker.errors.APIError as e:
-                    print(f"Warning: Could not remove container {container_name}: {e}")
+                    logger.warning(
+                        "Could not remove container %s: %s", container_name, e
+                    )
+
 
 # Example Usage (for testing):
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         manager = SandboxManager()
-        
+
         # Create dummy code directory and file for testing
-        test_code_dir = Path('./temp_sandbox_test_code')
+        test_code_dir = Path("./temp_sandbox_test_code")
         test_code_dir.mkdir(exist_ok=True)
-        script_path = test_code_dir / 'test_script.py'
+        script_path = test_code_dir / "test_script.py"
         script_content = """
 import sys
 import time
 import numpy as np # Test dependency
 
-print('Hello from sandbox!')
-print(f'Numpy version: {np.__version__}')
+# Example script messages
+logger.info('Hello from sandbox!')
+logger.info('Numpy version: %s', np.__version__)
 # print('Writing to stderr', file=sys.stderr)
 # time.sleep(5) # Test timeout
 # sys.exit(1) # Test non-zero exit code
 # with open('/etc/passwd', 'r') as f: print(f.read()) # Test read-only filesystem / disallowed access
 """
-        with open(script_path, 'w') as f:
+        with open(script_path, "w") as f:
             f.write(script_content)
 
-        print(f"\n--- Running Test Script --- (Directory: {test_code_dir.resolve()})")
+        logger.info(
+            "\n--- Running Test Script --- (Directory: %s)", test_code_dir.resolve()
+        )
         exit_c, out, err = manager.run_code_in_sandbox(
             code_directory=test_code_dir,
-            command=['python', 'test_script.py'], # Command relative to mounted /sandbox/code
-            timeout=10 # Shorter timeout for test
+            command=[
+                "python",
+                "test_script.py",
+            ],  # Command relative to mounted /sandbox/code
+            timeout=10,  # Shorter timeout for test
         )
 
-        print("\n--- Results ---")
-        print(f"Exit Code: {exit_c}")
-        print("\nStdout:")
-        print(out)
-        print("\nStderr:")
-        print(err)
-        print("---------------")
-        
+        logger.info("\n--- Results ---")
+        logger.info("Exit Code: %s", exit_c)
+        logger.info("\nStdout:\n%s", out)
+        logger.info("\nStderr:\n%s", err)
+        logger.info("---------------")
+
         # Clean up dummy code
         # script_path.unlink()
         # test_code_dir.rmdir()
 
     except (ConnectionError, SandboxExecutionError, FileNotFoundError) as e:
-        print(f"\nError during sandbox test: {e}")
+        logger.error("\nError during sandbox test: %s", e)
     except Exception as e:
-        print(f"An unexpected error occurred during testing: {e}")
+        logger.error("An unexpected error occurred during testing: %s", e)

--- a/src/meta_agent/utils/logging.py
+++ b/src/meta_agent/utils/logging.py
@@ -2,24 +2,43 @@ import sys
 from typing import Optional
 
 import logging
+from logging.handlers import RotatingFileHandler
 
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s %(levelname)s %(name)s %(message)s',
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
 )
 
-logger = logging.getLogger('meta_agent')
+logger = logging.getLogger("meta_agent")
 
-def setup_logging(name: str, level: str = 'INFO', log_file: Optional[str] = None) -> logging.Logger:
-    """Configure and return a logger that writes to stdout or a file."""
+
+def setup_logging(
+    name: str,
+    level: str = "INFO",
+    log_file: Optional[str] = None,
+    max_bytes: int = 0,
+    backup_count: int = 3,
+) -> logging.Logger:
+    """Configure and return a logger that writes to stdout or a file.
+
+    If ``log_file`` is provided and ``max_bytes`` is greater than ``0`` a
+    :class:`~logging.handlers.RotatingFileHandler` will be used to enable log
+    rotation.
+    """
+
     log = logging.getLogger(name)
     log.handlers.clear()
     levelno = getattr(logging, level.upper(), logging.INFO)
     log.setLevel(levelno)
-    formatter = logging.Formatter('%(message)s')
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
 
     if log_file:
-        fh = logging.FileHandler(log_file, encoding='utf-8')
+        if max_bytes > 0:
+            fh: logging.Handler = RotatingFileHandler(
+                log_file, maxBytes=max_bytes, backupCount=backup_count, encoding="utf-8"
+            )
+        else:
+            fh = logging.FileHandler(log_file, encoding="utf-8")
         fh.setLevel(levelno)
         fh.setFormatter(formatter)
         log.addHandler(fh)
@@ -28,4 +47,5 @@ def setup_logging(name: str, level: str = 'INFO', log_file: Optional[str] = None
         sh.setLevel(levelno)
         sh.setFormatter(formatter)
         log.addHandler(sh)
+
     return log

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -1,10 +1,14 @@
+from logging.handlers import RotatingFileHandler
+
 from meta_agent.utils.logging import setup_logging
+
 
 def test_setup_logging_stream(capfd):
     logger = setup_logging(name="test_logger", level="DEBUG")
     logger.debug("stream message")
     captured = capfd.readouterr()
     assert "stream message" in captured.out
+
 
 def test_setup_logging_file(tmp_path):
     log_file = tmp_path / "test.log"
@@ -13,3 +17,18 @@ def test_setup_logging_file(tmp_path):
     assert log_file.exists()
     content = log_file.read_text()
     assert "file message" in content
+
+
+def test_setup_logging_rotation(tmp_path):
+    log_file = tmp_path / "rotate.log"
+    logger = setup_logging(
+        name="rotate_logger",
+        level="INFO",
+        log_file=str(log_file),
+        max_bytes=10,
+        backup_count=1,
+    )
+    assert isinstance(logger.handlers[0], RotatingFileHandler)
+    logger.info("rotated message")
+    assert log_file.exists()
+    assert log_file.read_text()

--- a/tests/unit/test_execution_module.py
+++ b/tests/unit/test_execution_module.py
@@ -38,3 +38,12 @@ def test_run_tests_propagates_error(monkeypatch, tmp_path):
     module = ExecutionModule(fake_manager)
     with pytest.raises(exec_mod.SandboxExecutionError):
         module.run_tests(tmp_path)
+
+
+def test_run_tests_logs(monkeypatch, tmp_path, caplog):
+    fake_manager = MagicMock()
+    fake_manager.run_code_in_sandbox.return_value = (0, "out", "err")
+    module = ExecutionModule(fake_manager)
+    with caplog.at_level("INFO", logger="meta_agent.evaluation.execution"):
+        module.run_tests(tmp_path)
+    assert any("Running tests in" in rec.getMessage() for rec in caplog.records)

--- a/tests/unit/test_result_collection_module.py
+++ b/tests/unit/test_result_collection_module.py
@@ -37,3 +37,14 @@ def test_execute_and_collect_propagates_error(monkeypatch, tmp_path):
     module = ResultCollectionModule(fake_exec)
     with pytest.raises(rc_mod.SandboxExecutionError):
         module.execute_and_collect(tmp_path)
+
+
+def test_execute_and_collect_logs(monkeypatch, tmp_path, caplog):
+    fake_exec = MagicMock()
+    fake_exec.run_tests.return_value = ExecutionResult(0, "out", "err")
+    module = ResultCollectionModule(fake_exec)
+    with caplog.at_level("INFO", logger="meta_agent.evaluation.result_collection"):
+        module.execute_and_collect(tmp_path)
+    assert any(
+        "Executing and collecting results" in r.getMessage() for r in caplog.records
+    )

--- a/tests/unit/test_sandbox_manager.py
+++ b/tests/unit/test_sandbox_manager.py
@@ -8,35 +8,38 @@ import docker
 
 # --- __init__ tests ---
 
+
 def test_init_connection_error(monkeypatch):
     fake_client = MagicMock()
     fake_client.ping.side_effect = docker.errors.DockerException("ping fail")
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     with pytest.raises(ConnectionError) as exc:
         SandboxManager()
     assert "Could not connect to Docker daemon" in str(exc.value)
 
 
-def test_init_missing_seccomp(monkeypatch, tmp_path, capsys):
+def test_init_missing_seccomp(monkeypatch, tmp_path, caplog):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     # Point seccomp path to a non-existent file
-    monkeypatch.setattr(sm, '_seccomp_profile_path', tmp_path / 'missing.json')
-    manager = SandboxManager()
+    monkeypatch.setattr(sm, "_seccomp_profile_path", tmp_path / "missing.json")
+    with caplog.at_level("WARNING", logger="meta_agent.sandbox.sandbox_manager"):
+        manager = SandboxManager()
     assert manager.seccomp_profile is None
-    captured = capsys.readouterr()
-    assert "Warning: Seccomp profile not found" in captured.out
+    assert any(
+        "Seccomp profile not found" in record.getMessage() for record in caplog.records
+    )
 
 
 def test_init_invalid_seccomp(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     # Write invalid JSON
-    bad_path = tmp_path / 'seccomp.json'
+    bad_path = tmp_path / "seccomp.json"
     bad_path.write_text("not json")
-    monkeypatch.setattr(sm, '_seccomp_profile_path', bad_path)
+    monkeypatch.setattr(sm, "_seccomp_profile_path", bad_path)
     manager = SandboxManager()
     assert manager.seccomp_profile is None
 
@@ -44,47 +47,51 @@ def test_init_invalid_seccomp(monkeypatch, tmp_path):
 def test_init_valid_seccomp(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     # Write valid JSON
-    good_path = tmp_path / 'seccomp.json'
+    good_path = tmp_path / "seccomp.json"
     data = {"foo": "bar"}
     good_path.write_text(json.dumps(data))
-    monkeypatch.setattr(sm, '_seccomp_profile_path', good_path)
+    monkeypatch.setattr(sm, "_seccomp_profile_path", good_path)
     manager = SandboxManager()
     assert manager.seccomp_profile == data
 
+
 # --- run_code_in_sandbox tests ---
+
 
 def test_run_code_in_sandbox_file_not_found(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     manager = SandboxManager()
     with pytest.raises(FileNotFoundError):
-        manager.run_code_in_sandbox(tmp_path / 'no_exist', ['cmd'])
+        manager.run_code_in_sandbox(tmp_path / "no_exist", ["cmd"])
 
 
 def test_run_code_in_sandbox_success(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
-    
+
     # Mock container behavior
     container = MagicMock()
-    container.wait.return_value = {'StatusCode': 42}
+    container.wait.return_value = {"StatusCode": 42}
+
     def logs_side(stdout, stderr):
-        return b'stdout' if stdout else b'stderr'
+        return b"stdout" if stdout else b"stderr"
+
     container.logs.side_effect = logs_side
     fake_client.containers.run.return_value = container
 
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     manager = SandboxManager()
 
-    code_dir = tmp_path / 'code'
+    code_dir = tmp_path / "code"
     code_dir.mkdir()
-    exit_code, out, err = manager.run_code_in_sandbox(code_dir, ['cmd'])
+    exit_code, out, err = manager.run_code_in_sandbox(code_dir, ["cmd"])
     assert exit_code == 42
-    assert out == 'stdout'
-    assert err == 'stderr'
+    assert out == "stdout"
+    assert err == "stderr"
     container.remove.assert_called_with(force=True)
 
 
@@ -92,12 +99,12 @@ def test_run_code_image_not_found(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
     fake_client.containers.run.side_effect = docker.errors.ImageNotFound("no image")
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     manager = SandboxManager()
-    code_dir = tmp_path / 'code'
+    code_dir = tmp_path / "code"
     code_dir.mkdir()
     with pytest.raises(SandboxExecutionError) as exc:
-        manager.run_code_in_sandbox(code_dir, ['cmd'])
+        manager.run_code_in_sandbox(code_dir, ["cmd"])
     assert "Sandbox image" in str(exc.value)
 
 
@@ -105,29 +112,29 @@ def test_run_code_api_error(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
     fake_client.containers.run.side_effect = docker.errors.APIError("api failed")
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     manager = SandboxManager()
-    code_dir = tmp_path / 'code'
+    code_dir = tmp_path / "code"
     code_dir.mkdir()
     with pytest.raises(SandboxExecutionError) as exc:
-        manager.run_code_in_sandbox(code_dir, ['cmd'])
+        manager.run_code_in_sandbox(code_dir, ["cmd"])
     assert "Failed to run sandbox container" in str(exc.value)
 
 
 def test_run_code_timeout(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
-    
+
     container = MagicMock()
     container.wait.side_effect = Exception("timeout")
     fake_client.containers.run.return_value = container
 
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     manager = SandboxManager()
-    code_dir = tmp_path / 'code'
+    code_dir = tmp_path / "code"
     code_dir.mkdir()
     with pytest.raises(SandboxExecutionError) as exc:
-        manager.run_code_in_sandbox(code_dir, ['cmd'], timeout=1)
+        manager.run_code_in_sandbox(code_dir, ["cmd"], timeout=1)
     assert "Execution timed out" in str(exc.value)
     container.stop.assert_called()
     container.remove.assert_called()
@@ -137,19 +144,19 @@ def test_security_opt_with_seccomp(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_client.ping.return_value = None
     container = MagicMock()
-    container.wait.return_value = {'StatusCode': 0}
-    container.logs.return_value = b''
+    container.wait.return_value = {"StatusCode": 0}
+    container.logs.return_value = b""
     fake_client.containers.run.return_value = container
 
-    monkeypatch.setattr(sm.docker, 'from_env', lambda: fake_client)
+    monkeypatch.setattr(sm.docker, "from_env", lambda: fake_client)
     manager = SandboxManager()
-    code_dir = tmp_path / 'code'
+    code_dir = tmp_path / "code"
     code_dir.mkdir()
     # Inject a fake seccomp profile
     manager.seccomp_profile = {"k": "v"}
-    manager.run_code_in_sandbox(code_dir, ['cmd'])
+    manager.run_code_in_sandbox(code_dir, ["cmd"])
     _, kwargs = fake_client.containers.run.call_args
-    assert 'security_opt' in kwargs
-    opts = kwargs['security_opt']
-    assert any(str(opt).startswith('seccomp=') for opt in opts)
+    assert "security_opt" in kwargs
+    opts = kwargs["security_opt"]
+    assert any(str(opt).startswith("seccomp=") for opt in opts)
     container.remove.assert_called_with(force=True)


### PR DESCRIPTION
## Summary
- implement rotating file support in logging setup
- add detailed logging to evaluation modules
- use logging in SandboxManager instead of print
- test new logging features and messages

## Testing
- `ruff check .` *(fails: E402 etc.)*
- `black --check .` *(fails: many files would be reformatted)*
- `mypy` *(fails: missing target module)*
- `pyright` *(fails: many errors)*
- `pytest` *(fails: pytest_asyncio missing)*