### PR TITLE
fix: sandbox manager validation tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -p pytest_asyncio -p no:anyio
+addopts = -p no:anyio
 asyncio_default_fixture_loop_scope = function
 norecursedirs = src/.tool_designer temp_sandbox_test_code .git .tox venv* *.egg* build dist
 markers =

--- a/pytest_asyncio.py
+++ b/pytest_asyncio.py
@@ -1,0 +1,18 @@
+import asyncio
+import inspect
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "asyncio: mark a test as running with asyncio"
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    test_func = pyfuncitem.obj
+    if inspect.iscoroutinefunction(test_func):
+        asyncio.run(test_func(**pyfuncitem.funcargs))
+        return True
+    return None

--- a/src/meta_agent/sandbox/sandbox_manager.py
+++ b/src/meta_agent/sandbox/sandbox_manager.py
@@ -15,6 +15,8 @@ DEFAULT_IMAGE_NAME = "meta-agent-sandbox:latest"
 DEFAULT_TIMEOUT_SECONDS = 60
 DEFAULT_MEM_LIMIT = "256m"
 DEFAULT_CPU_SHARES = 512  # Relative weight, 1024 is default
+MAX_CPU_SHARES = 2048
+SUSPICIOUS_PATTERNS = ["traceback", "permission denied", "segmentation fault"]
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +64,32 @@ class SandboxManager:
             # Optionally raise an error if seccomp is critical
             # raise ValueError("Invalid seccomp profile JSON") from e
 
+    def _validate_inputs(
+        self,
+        code_directory: Path,
+        command: list[str],
+        mem_limit: str,
+        cpu_shares: int,
+    ) -> None:
+        """Validate inputs and resource limits for sandbox execution."""
+
+
+
+        if not code_directory.is_dir():
+            raise FileNotFoundError(f"Code directory not found: {code_directory}")
+
+        if not command or any(
+            not isinstance(c, str) or any(x in c for x in [";", "&", "|", "`", "\n"])
+            for c in command
+        ):
+            raise ValueError("Invalid command passed to sandbox")
+
+        if cpu_shares <= 0 or cpu_shares > MAX_CPU_SHARES:
+            raise ValueError("cpu_shares out of allowed range")
+
+        if mem_limit[-1].lower() not in {"m", "g"} or not mem_limit[:-1].isdigit():
+            raise ValueError("mem_limit must be like '256m' or '1g'")
+
     def run_code_in_sandbox(
         self,
         code_directory: Path,
@@ -90,8 +118,12 @@ class SandboxManager:
             SandboxExecutionError: If there's an error running the container or execution times out.
             FileNotFoundError: If the code_directory doesn't exist.
         """
-        if not code_directory.is_dir():
-            raise FileNotFoundError(f"Code directory not found: {code_directory}")
+        self._validate_inputs(
+            code_directory=code_directory,
+            command=command,
+            mem_limit=mem_limit,
+            cpu_shares=cpu_shares,
+        )
 
         container_name = f"meta-agent-sandbox-run-{os.urandom(4).hex()}"
 
@@ -166,6 +198,10 @@ class SandboxManager:
             stderr = container.logs(stdout=False, stderr=True).decode(
                 "utf-8", errors="replace"
             )
+
+            lower_output = f"{stdout}\n{stderr}".lower()
+            if any(pat in lower_output for pat in SUSPICIOUS_PATTERNS):
+                logger.warning("Suspicious output detected during sandbox run")
 
             logger.info("Sandbox execution finished with exit code: %s", exit_code)
             return exit_code, stdout, stderr

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,11 @@
+from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+pytest_plugins = ["pytest_asyncio"]
+
+# Ensure the src directory is on the path for tests
+src_dir = Path(__file__).resolve().parent.parent / "src"
+if str(src_dir) not in sys.path:
+    sys.path.insert(0, str(src_dir))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+docker_mock = MagicMock()
+docker_mock.errors = SimpleNamespace(
+    DockerException=Exception,
+    APIError=Exception,
+    ImageNotFound=Exception,
+    NotFound=Exception,
+)
+# Provide from_env to be patched later in tests
+docker_mock.from_env = MagicMock()
+
+sys.modules.setdefault("docker", docker_mock)


### PR DESCRIPTION
## Summary
- create simple pytest_asyncio plugin for local tests
- stub docker module during unit tests
- validate sandbox inputs before execution
- adjust pytest config to avoid missing plugin errors

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `mypy src/meta_agent/sandbox/sandbox_manager.py tests/unit/test_sandbox_manager.py` *(fails: library stubs not installed for "docker")*
- `pyright src/meta_agent/sandbox/sandbox_manager.py tests/unit/test_sandbox_manager.py` *(fails: "errors" is not a known attribute of module "docker")*
- `PYTHONPATH=src pytest tests/unit/test_sandbox_manager.py::test_invalid_command tests/unit/test_sandbox_manager.py::test_invalid_resources tests/unit/test_sandbox_manager.py::test_suspicious_output_logs -q`