### PR TITLE
feat: add evaluation harness

### DIFF
--- a/src/meta_agent/evaluation/__init__.py
+++ b/src/meta_agent/evaluation/__init__.py
@@ -3,6 +3,7 @@
 from .execution import ExecutionModule, ExecutionResult
 from .result_collection import CollectionResult, ResultCollectionModule
 from .reporting import ReportingModule, SummaryReport
+from .harness import EvaluationHarness
 
 __all__ = [
     "ExecutionModule",
@@ -11,4 +12,5 @@ __all__ = [
     "CollectionResult",
     "ReportingModule",
     "SummaryReport",
+    "EvaluationHarness",
 ]

--- a/src/meta_agent/evaluation/harness.py
+++ b/src/meta_agent/evaluation/harness.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import logging
+
+from .execution import ExecutionModule
+from .result_collection import ResultCollectionModule, CollectionResult
+from .reporting import ReportingModule
+
+
+class EvaluationHarness:
+    """Coordinate execution, collection and reporting of tests."""
+
+    def __init__(
+        self,
+        result_collector: Optional[ResultCollectionModule] = None,
+        reporter: Optional[ReportingModule] = None,
+    ) -> None:
+        self.result_collector = result_collector or ResultCollectionModule()
+        self.reporter = reporter or ReportingModule()
+        self.logger = logging.getLogger(__name__)
+
+    def evaluate(
+        self,
+        path: Path,
+        timeout: int = 60,
+        output_format: str = "text",
+    ) -> str:
+        """Run tests at ``path`` and return a formatted report."""
+        self.logger.info("Starting evaluation for %s", path)
+        result: CollectionResult = self.result_collector.execute_and_collect(
+            path, timeout=timeout
+        )
+        return self.reporter.generate_report(result, output_format=output_format)

--- a/tests/unit/test_evaluation_harness.py
+++ b/tests/unit/test_evaluation_harness.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock
+
+from meta_agent.evaluation.harness import EvaluationHarness
+from meta_agent.evaluation.result_collection import CollectionResult
+
+
+def test_init_creates_default_modules(monkeypatch):
+    fake_rc_cls = MagicMock()
+    fake_rc = MagicMock()
+    fake_rc_cls.return_value = fake_rc
+    fake_reporter_cls = MagicMock()
+    fake_reporter = MagicMock()
+    fake_reporter_cls.return_value = fake_reporter
+    monkeypatch.setattr(
+        'meta_agent.evaluation.harness.ResultCollectionModule', fake_rc_cls
+    )
+    monkeypatch.setattr('meta_agent.evaluation.harness.ReportingModule', fake_reporter_cls)
+
+    harness = EvaluationHarness()
+    assert harness.result_collector is fake_rc
+    assert harness.reporter is fake_reporter
+
+
+def test_evaluate_flow(monkeypatch, tmp_path):
+    fake_rc = MagicMock()
+    collection = CollectionResult(exit_code=0, stdout='out', stderr='err', duration=1.0)
+    fake_rc.execute_and_collect.return_value = collection
+    fake_reporter = MagicMock()
+    fake_reporter.generate_report.return_value = 'REPORT'
+
+    harness = EvaluationHarness(fake_rc, fake_reporter)
+    result = harness.evaluate(tmp_path, timeout=5, output_format='json')
+
+    assert result == 'REPORT'
+    fake_rc.execute_and_collect.assert_called_with(tmp_path, timeout=5)
+    fake_reporter.generate_report.assert_called_with(collection, output_format='json')
+
+
+def test_evaluate_logs(monkeypatch, tmp_path, caplog):
+    fake_rc = MagicMock()
+    fake_rc.execute_and_collect.return_value = CollectionResult(0, '', '', 0.1)
+    fake_reporter = MagicMock()
+    fake_reporter.generate_report.return_value = ''
+    harness = EvaluationHarness(fake_rc, fake_reporter)
+    with caplog.at_level('INFO', logger='meta_agent.evaluation.harness'):
+        harness.evaluate(tmp_path)
+    assert any('Starting evaluation for' in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- implement `EvaluationHarness` to coordinate evaluation modules
- export new harness in evaluation package
- add unit tests for the harness

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`
- `mypy`
- `pyright`
