### PR TITLE
feat: add bundle metadata schema

### DIFF
--- a/docs/bundle_layout.md
+++ b/docs/bundle_layout.md
@@ -1,0 +1,42 @@
+# Bundle Layout
+
+This document specifies the directory structure and metadata schema for the artefact bundle produced by Meta Agent.
+
+## Directory Structure
+
+```
+<bundle>/
+├── agent.py              # entry point for the generated agent
+├── requirements.txt      # pinned dependencies
+├── README.md             # usage instructions
+├── tests/                # unit tests
+├── guardrails/           # guardrail definitions and tests
+├── traces/               # evaluation logs
+└── bundle.json           # metadata file
+```
+
+Additional files may be placed under `tests/`, `guardrails/` or `traces/` but the files listed above are required. Future versions may add optional directories; consumers should ignore unknown entries.
+
+## Metadata Schema
+
+The `bundle.json` file describes the bundle.  The schema is versioned so that new
+fields can be introduced without breaking existing tooling.
+
+```json
+{
+  "schema_version": "1.0",
+  "created_at": "2025-01-01T00:00:00Z",
+  "meta_agent_version": "0.1.0",
+  "custom": {"key": "value"}
+}
+```
+
+- `schema_version` — fixed string identifying the structure of the metadata.
+- `created_at` — ISO‑8601 timestamp of when the bundle was generated.
+- `meta_agent_version` — version of Meta Agent that produced the bundle.
+- `custom` — arbitrary key/value pairs for extensibility. Unknown top-level fields
+  are allowed and preserved.
+
+Custom fields may also be added at the top level by future components. Tools
+reading the metadata should ignore unrecognised fields while still enforcing the
+presence of `schema_version`.

--- a/src/meta_agent/models/__init__.py
+++ b/src/meta_agent/models/__init__.py
@@ -1,1 +1,5 @@
-# models package init
+"""Model exports."""
+
+from .bundle_metadata import BundleMetadata, BUNDLE_SCHEMA_VERSION
+
+__all__ = ["BundleMetadata", "BUNDLE_SCHEMA_VERSION"]

--- a/src/meta_agent/models/bundle_metadata.py
+++ b/src/meta_agent/models/bundle_metadata.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+BUNDLE_SCHEMA_VERSION = "1.0"
+
+
+class BundleMetadata(BaseModel):
+    """Metadata describing a generated agent bundle."""
+
+    schema_version: str = Field(
+        default=BUNDLE_SCHEMA_VERSION,
+        description="Version of the bundle metadata schema.",
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp when the bundle was created (UTC).",
+    )
+    meta_agent_version: Optional[str] = Field(
+        default=None,
+        description="Version of Meta Agent that produced the bundle.",
+    )
+    custom: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary metadata fields for extensibility.",
+    )
+
+    class Config:
+        extra = "allow"  # Preserve unknown fields for forward compatibility

--- a/tests/test_bundle_metadata.py
+++ b/tests/test_bundle_metadata.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from meta_agent.models.bundle_metadata import BundleMetadata, BUNDLE_SCHEMA_VERSION
+
+
+def test_bundle_metadata_defaults():
+    meta = BundleMetadata()
+    assert meta.schema_version == BUNDLE_SCHEMA_VERSION
+    assert isinstance(meta.created_at, datetime)
+    assert meta.custom == {}
+
+
+def test_bundle_metadata_custom_fields_preserved():
+    data = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "meta_agent_version": "0.1.0",
+        "foo": "bar",
+        "custom": {"x": 1},
+    }
+    meta = BundleMetadata(**data)
+    assert meta.meta_agent_version == "0.1.0"
+    assert meta.custom == {"x": 1}
+    assert getattr(meta, "foo") == "bar"


### PR DESCRIPTION
## Summary
- document bundle layout and metadata JSON schema
- implement `BundleMetadata` model
- export bundle metadata from models package
- test bundle metadata behaviour

## Testing
- `ruff check src/meta_agent/models/bundle_metadata.py tests/test_bundle_metadata.py src/meta_agent/models/__init__.py`
- `black --check src/meta_agent/models/bundle_metadata.py tests/test_bundle_metadata.py src/meta_agent/models/__init__.py`
- `pytest tests/test_bundle_metadata.py -q`
- `mypy src/meta_agent/models/bundle_metadata.py`
- `pyright src/meta_agent/models/bundle_metadata.py`
- `ruff check .` *(fails: E402 etc.)*
- `black --check .` *(fails: would reformat many files)*
- `mypy src/meta_agent` *(fails: missing stubs)*
- `pyright` *(fails: many errors)*
- `pytest -q` *(fails: ModuleNotFoundError: jinja2, etc.)*