### PR TITLE
fix: handle metadata override

### DIFF
--- a/docs/bundle_layout.md
+++ b/docs/bundle_layout.md
@@ -19,8 +19,11 @@ Additional files may be placed under `tests/`, `guardrails/` or `traces/` but th
 
 ## Metadata Schema
 
-The `bundle.json` file describes the bundle.  The schema is versioned so that new
-fields can be introduced without breaking existing tooling.
+The `bundle.json` file describes the bundle. The schema is versioned so that new
+fields can be introduced without breaking existing tooling. The `BundleGenerator`
+allows callers to inject additional metadata fields when creating a bundle, which
+will be included in this file. The `meta_agent_version` field is populated from
+the running package version unless you supply a value using `metadata_fields`.
 
 ```json
 {
@@ -35,8 +38,11 @@ fields can be introduced without breaking existing tooling.
 - `created_at` — ISO‑8601 timestamp of when the bundle was generated.
 - `meta_agent_version` — version of Meta Agent that produced the bundle.
 - `custom` — arbitrary key/value pairs for extensibility. Unknown top-level fields
-  are allowed and preserved.
+  are allowed and preserved. Use `custom_metadata` when invoking `BundleGenerator`
+  to populate this section.
 
 Custom fields may also be added at the top level by future components. Tools
 reading the metadata should ignore unrecognised fields while still enforcing the
 presence of `schema_version`.
+You can supply additional top-level keys using the `metadata_fields` argument
+when generating a bundle.

--- a/src/meta_agent/bundle_generator.py
+++ b/src/meta_agent/bundle_generator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import hashlib
 from pathlib import Path
-from typing import Mapping, Sequence, Optional
+from typing import Mapping, Sequence, Optional, Any
 
 from .models import BundleMetadata
 from .__about__ import __version__
@@ -30,6 +30,8 @@ class BundleGenerator:
         readme: str = "",
         guardrails_manifest: str = "",
         templates: Optional[Mapping[str, str]] = None,
+        metadata_fields: Optional[Mapping[str, Any]] = None,
+        custom_metadata: Optional[Mapping[str, Any]] = None,
     ) -> BundleMetadata:
         """Generate bundle files and return metadata."""
 
@@ -44,7 +46,9 @@ class BundleGenerator:
             checksums[f"tests/{name}"] = self._write_file(Path("tests") / name, content)
 
         req_content = "\n".join(requirements or [])
-        checksums["requirements.txt"] = self._write_file("requirements.txt", req_content)
+        checksums["requirements.txt"] = self._write_file(
+            "requirements.txt", req_content
+        )
 
         checksums["README.md"] = self._write_file("README.md", readme)
 
@@ -59,8 +63,16 @@ class BundleGenerator:
         for rel, content in (templates or {}).items():
             checksums[str(rel)] = self._write_file(rel, content)
 
-        metadata = BundleMetadata(meta_agent_version=__version__)
+        metadata_fields = dict(metadata_fields or {})
+        custom_metadata = custom_metadata or {}
+
+        version = metadata_fields.pop("meta_agent_version", __version__)
+        metadata = BundleMetadata(meta_agent_version=version, **metadata_fields)
+        metadata.custom.update(custom_metadata)
         metadata.custom["checksums"] = checksums
         with open(self.bundle_dir / "bundle.json", "w", encoding="utf-8") as f:
-            json.dump(json.loads(metadata.model_dump_json()), f, indent=2)
+            dump_json = (
+                metadata.model_dump_json() if hasattr(metadata, "model_dump_json") else metadata.json()
+            )
+            json.dump(json.loads(dump_json), f, indent=2)
         return metadata

--- a/tests/test_bundle_generator.py
+++ b/tests/test_bundle_generator.py
@@ -8,7 +8,7 @@ from meta_agent.models import BUNDLE_SCHEMA_VERSION
 
 def test_bundle_generator_creates_files(tmp_path: Path) -> None:
     gen = BundleGenerator(tmp_path)
-    metadata = gen.generate(
+    gen.generate(
         agent_code="print('agent')",
         tests={"test_sample.py": "def test_sample():\n    assert True"},
         requirements=["foo==1.0"],
@@ -40,3 +40,19 @@ def test_bundle_generator_templates(tmp_path: Path) -> None:
     assert (tmp_path / "extra.txt").exists()
     with open(tmp_path / "extra.txt", encoding="utf-8") as f:
         assert f.read() == "hello"
+
+
+def test_bundle_generator_custom_metadata(tmp_path: Path) -> None:
+    gen = BundleGenerator(tmp_path)
+    gen.generate(
+        agent_code="print('agent')",
+        metadata_fields={"meta_agent_version": "1.2.3", "extra": "field"},
+        custom_metadata={"tag": "example"},
+    )
+
+    with open(tmp_path / "bundle.json", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["meta_agent_version"] == "1.2.3"
+    assert data["extra"] == "field"
+    assert data["custom"]["tag"] == "example"


### PR DESCRIPTION
## Summary
- allow overriding `meta_agent_version` when generating bundles
- document how to override the version
- ensure metadata dumping works with both Pydantic v1 and v2

## Testing
- `ruff check . | head -n 20`
- `black --check . | head -n 20`
- `pytest -q 2>&1 | head -n 20`
- `mypy . | head -n 20`
- `pyright | head -n 20`
