### PR TITLE
feat: add optional git integration

### DIFF
--- a/src/meta_agent/git_utils.py
+++ b/src/meta_agent/git_utils.py
@@ -1,0 +1,64 @@
+"""Utilities for optional Git integration when generating bundles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import shutil
+import subprocess
+
+
+class GitManager:
+    """Lightweight wrapper around Git commands."""
+
+    def __init__(self, repo_dir: str | Path) -> None:
+        self.repo_dir = Path(repo_dir)
+
+    @staticmethod
+    def git_available() -> bool:
+        """Return True if the ``git`` executable can be found."""
+        return shutil.which("git") is not None
+
+    def _run(
+        self, *args: str, env: dict | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        if not self.git_available():
+            raise RuntimeError("git executable not found")
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repo_dir,
+            text=True,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+
+    def init(self) -> None:
+        """Initialize a new repository if one does not already exist."""
+        if (self.repo_dir / ".git").exists():
+            return
+        self.repo_dir.mkdir(parents=True, exist_ok=True)
+        self._run("init")
+        self._run("config", "user.name", "meta-agent")
+        self._run("config", "user.email", "meta-agent@example.com")
+        self._run("branch", "-M", "main")
+
+    def commit_all(self, message: str = "Initial commit") -> str:
+        """Add all files and create a commit.
+
+        Returns the commit SHA.
+        """
+        env = os.environ.copy()
+        # Deterministic commit timestamp
+        env.setdefault("GIT_AUTHOR_DATE", "1970-01-01T00:00:00+0000")
+        env.setdefault("GIT_COMMITTER_DATE", "1970-01-01T00:00:00+0000")
+        self._run("add", "-A", env=env)
+        self._run("commit", "-m", message, env=env)
+        result = self._run("rev-parse", "HEAD", env=env)
+        return result.stdout.strip()
+
+    def add_remote(self, name: str, url: str) -> None:
+        self._run("remote", "add", name, url)
+
+    def push(self, remote: str = "origin", branch: str = "main") -> None:
+        self._run("push", remote, f"HEAD:{branch}")

--- a/tests/test_git_utils.py
+++ b/tests/test_git_utils.py
@@ -1,0 +1,35 @@
+import subprocess
+from pathlib import Path
+
+from meta_agent.git_utils import GitManager
+
+
+def test_git_manager_init_and_commit(tmp_path: Path) -> None:
+    gm = GitManager(tmp_path)
+    gm.init()
+    (tmp_path / "foo.txt").write_text("hi")
+    sha = gm.commit_all("init")
+
+    assert (tmp_path / ".git").exists()
+    out = subprocess.check_output(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"], text=True
+    ).strip()
+    assert out == sha
+
+
+def test_git_manager_push(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True)
+
+    repo = tmp_path / "repo"
+    gm = GitManager(repo)
+    gm.init()
+    (repo / "bar.txt").write_text("bar")
+    gm.commit_all("first")
+    gm.add_remote("origin", str(remote))
+    gm.push("origin", "main")
+
+    log = subprocess.check_output(
+        ["git", "-C", str(remote), "log", "--oneline"], text=True
+    )
+    assert "first" in log


### PR DESCRIPTION
## Summary
- implement `GitManager` for optional git operations
- integrate git support into `BundleGenerator`
- add tests for git utilities and bundle generator git flow

## Testing
- `ruff check .` *(fails: Module level import not at top of file, unused imports)*
- `black --check src/meta_agent/bundle_generator.py src/meta_agent/git_utils.py tests/test_bundle_generator.py tests/test_git_utils.py`
- `mypy src/meta_agent/bundle_generator.py src/meta_agent/git_utils.py tests/test_git_utils.py tests/test_bundle_generator.py`
- `pyright src/meta_agent/bundle_generator.py src/meta_agent/git_utils.py tests/test_bundle_generator.py tests/test_git_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*