### PR TITLE
fix: bundle validator tests

### DIFF
--- a/src/meta_agent/bundle_validator.py
+++ b/src/meta_agent/bundle_validator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import py_compile
+import subprocess
+from pathlib import Path
+from typing import List
+
+from .models import BundleMetadata
+from .models.validation_result import ValidationResult
+
+
+class BundleValidator:
+    """Validate the contents of a generated agent bundle."""
+
+    def __init__(self, bundle_dir: str | Path) -> None:
+        self.bundle_dir = Path(bundle_dir)
+
+    def _load_metadata(self) -> BundleMetadata:
+        with open(self.bundle_dir / "bundle.json", encoding="utf-8") as f:
+            data = json.load(f)
+        return BundleMetadata(**data)
+
+    def _validate_checksums(self, metadata: BundleMetadata, errors: List[str]) -> None:
+        checksums = metadata.custom.get("checksums", {})
+        for rel, expected in checksums.items():
+            path = self.bundle_dir / rel
+            if not path.exists():
+                errors.append(f"missing file {rel}")
+                continue
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            if digest != expected:
+                errors.append(f"checksum mismatch for {rel}")
+
+    def _validate_requirements(self, errors: List[str]) -> None:
+        req_path = self.bundle_dir / "requirements.txt"
+        if not req_path.exists():
+            errors.append("requirements.txt missing")
+            return
+        for line in req_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "==" not in line:
+                errors.append(f"unpinned requirement: {line}")
+
+    def _validate_agent(self, errors: List[str]) -> None:
+        try:
+            py_compile.compile(str(self.bundle_dir / "agent.py"), doraise=True)
+        except py_compile.PyCompileError as exc:
+            errors.append(f"agent.py failed to compile: {exc.msg}")
+
+    def _run_tests(self, errors: List[str]) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(self.bundle_dir)
+        result = subprocess.run(
+            ["pytest", "tests", "-c", "/dev/null", "-x"],
+            cwd=self.bundle_dir,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if result.returncode != 0:
+            errors.append("tests failed")
+
+    def validate(self) -> ValidationResult:
+        errors: List[str] = []
+        try:
+            metadata = self._load_metadata()
+        except Exception as exc:  # pragma: no cover - invalid json path rare
+            errors.append(f"invalid bundle metadata: {exc}")
+            return ValidationResult(success=False, errors=errors, coverage=0.0)
+
+        self._validate_checksums(metadata, errors)
+        self._validate_requirements(errors)
+        self._validate_agent(errors)
+
+        if not errors:
+            self._run_tests(errors)
+
+        success = not errors
+        return ValidationResult(success=success, errors=errors, coverage=0.0)

--- a/tests/integration/test_llm_service_integration.py
+++ b/tests/integration/test_llm_service_integration.py
@@ -1,12 +1,30 @@
-import pytest
 import os
+import socket
+
+import pytest
 from meta_agent.services.llm_service import LLMService
 
-@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set in environment for integration test")
+
+def internet_available() -> bool:
+    try:
+        socket.create_connection(("api.openai.com", 443), timeout=1).close()
+        return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set in environment for integration test",
+)
+@pytest.mark.skipif(
+    not internet_available(),
+    reason="Network not available for integration test",
+)
 @pytest.mark.asyncio
 async def test_llm_service_live_api_call():
     """Tests that LLMService can make a successful live API call.
-    
+
     This test relies on the OPENAI_API_KEY environment variable being set.
     It uses the default model and API base configured in LLMService.
     """
@@ -14,21 +32,28 @@ async def test_llm_service_live_api_call():
         # LLMService will attempt to load the API key from .env or environment
         service = LLMService()
     except ValueError as e:
-        pytest.fail(f"Failed to initialize LLMService, API key likely missing or invalid: {e}")
+        pytest.fail(
+            f"Failed to initialize LLMService, API key likely missing or invalid: {e}"
+        )
 
     simple_prompt = "Say hello in one sentence."
     context = {}
 
     try:
         code_response = await service.generate_code(simple_prompt, context)
-        
+
         assert isinstance(code_response, str), "Response should be a string"
         assert len(code_response.strip()) > 0, "Response string should not be empty"
         # We are not asserting the *content* of the response, just that we got one.
-        print(f"Successfully received response from LLMService: {code_response[:100]}...")
+        print(
+            f"Successfully received response from LLMService: {code_response[:100]}..."
+        )
 
     except Exception as e:
-        pytest.fail(f"LLMService.generate_code failed with an unexpected exception: {e}")
+        pytest.fail(
+            f"LLMService.generate_code failed with an unexpected exception: {e}"
+        )
+
 
 # To run this test specifically (ensure .env or OPENAI_API_KEY is set):
 # uv pip install -r uv.lock --extra test && pytest tests/integration/test_llm_service_integration.py

--- a/tests/test_bundle_validator.py
+++ b/tests/test_bundle_validator.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from meta_agent.bundle_generator import BundleGenerator
+from meta_agent.bundle_validator import BundleValidator
+
+
+def create_sample_bundle(tmp_path: Path) -> Path:
+    gen = BundleGenerator(tmp_path)
+    gen.generate(
+        agent_code="def main():\n    return 'ok'",
+        tests={
+            "test_main.py": "from agent import main\n\ndef test_main():\n    assert main() == 'ok'",
+        },
+        requirements=["pytest==8.0.0"],
+        readme="# Sample",
+    )
+    return tmp_path
+
+
+def test_bundle_validator_success(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is True
+    assert result.errors == []
+
+
+def test_bundle_validator_checksum_failure(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "agent.py").write_text("broken")
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("checksum mismatch" in e for e in result.errors)
+
+
+def test_bundle_validator_unpinned_requirement(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "requirements.txt").write_text("pytest>=8")
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("unpinned requirement" in e for e in result.errors)
+
+
+def test_bundle_validator_test_failure(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    failing_test = bundle_dir / "tests" / "test_main.py"
+    failing_test.write_text("def test_fail():\n    assert False")
+    # update checksum so validation reaches test execution
+    import hashlib
+    import json
+
+    bundle_file = bundle_dir / "bundle.json"
+    data = json.loads(bundle_file.read_text())
+    digest = hashlib.sha256(failing_test.read_bytes()).hexdigest()
+    data["custom"]["checksums"]["tests/test_main.py"] = digest
+    bundle_file.write_text(json.dumps(data))
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("tests failed" in e for e in result.errors)


### PR DESCRIPTION
## Summary
- ensure bundle validator runs tests in isolated environment
- update checksum in failing test
- skip llm integration test when network unavailable

## Testing
- `ruff check src/meta_agent/bundle_validator.py tests/test_bundle_validator.py tests/integration/test_llm_service_integration.py`
- `black --check src/meta_agent/bundle_validator.py tests/test_bundle_validator.py tests/integration/test_llm_service_integration.py`
- `mypy src/meta_agent` *(fails: Cannot find implementation or library stub for module named "agents")*
- `pyright` *(fails: "Agent" is unknown import symbol)*
- `pytest -q`