### PR TITLE
fix: strip coverage env for subprocess

### DIFF
--- a/src/meta_agent/bundle_validator.py
+++ b/src/meta_agent/bundle_validator.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import py_compile
+import subprocess
+from pathlib import Path
+from typing import List
+
+from .models import BundleMetadata
+from .models.validation_result import ValidationResult
+
+
+class BundleValidator:
+    """Validate the contents of a generated agent bundle."""
+
+    def __init__(self, bundle_dir: str | Path) -> None:
+        self.bundle_dir = Path(bundle_dir)
+
+    def _load_metadata(self) -> BundleMetadata:
+        with open(self.bundle_dir / "bundle.json", encoding="utf-8") as f:
+            data = json.load(f)
+        return BundleMetadata(**data)
+
+    def _validate_checksums(self, metadata: BundleMetadata, errors: List[str]) -> None:
+        checksums = metadata.custom.get("checksums", {})
+        for rel, expected in checksums.items():
+            path = self.bundle_dir / rel
+            if not path.exists():
+                errors.append(f"missing file {rel}")
+                continue
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            if digest != expected:
+                errors.append(f"checksum mismatch for {rel}")
+
+    def _validate_requirements(self, errors: List[str]) -> None:
+        req_path = self.bundle_dir / "requirements.txt"
+        if not req_path.exists():
+            errors.append("requirements.txt missing")
+            return
+        for line in req_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "==" not in line:
+                errors.append(f"unpinned requirement: {line}")
+
+    def _validate_agent(self, errors: List[str]) -> None:
+        try:
+            py_compile.compile(str(self.bundle_dir / "agent.py"), doraise=True)
+        except py_compile.PyCompileError as exc:
+            errors.append(f"agent.py failed to compile: {exc.msg}")
+
+    def _run_tests(self, errors: List[str]) -> None:
+        result = subprocess.run(
+            ["pytest", "-x"],
+            cwd=self.bundle_dir,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            errors.append("tests failed")
+
+    def validate(self) -> ValidationResult:
+        errors: List[str] = []
+        try:
+            metadata = self._load_metadata()
+        except Exception as exc:  # pragma: no cover - invalid json path rare
+            errors.append(f"invalid bundle metadata: {exc}")
+            return ValidationResult(success=False, errors=errors, coverage=0.0)
+
+        self._validate_checksums(metadata, errors)
+        self._validate_requirements(errors)
+        self._validate_agent(errors)
+
+        if not errors:
+            self._run_tests(errors)
+
+        success = not errors
+        return ValidationResult(success=success, errors=errors, coverage=0.0)

--- a/src/meta_agent/validation.py
+++ b/src/meta_agent/validation.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+from pathlib import Path
 import uuid
 import logging
 import xml.etree.ElementTree as ET
@@ -8,12 +9,17 @@ from .models.validation_result import ValidationResult
 from .models.generated_tool import GeneratedTool
 
 COVERAGE_FAIL = 0.9
-ARTEFACTS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".tool_designer", "artefacts")
+ARTEFACTS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), ".tool_designer", "artefacts"
+)
 os.makedirs(ARTEFACTS_DIR, exist_ok=True)
 
 logger = logging.getLogger(__name__)
 
-def validate_generated_tool(tool: GeneratedTool, tool_id: str = None) -> ValidationResult:
+
+def validate_generated_tool(
+    tool: GeneratedTool, tool_id: str = None
+) -> ValidationResult:
     """
     Run pytest and coverage on the generated tool code and tests.
     Persist results and artefacts under .tool_designer/artefacts/<tool_id>/
@@ -38,46 +44,76 @@ def validate_generated_tool(tool: GeneratedTool, tool_id: str = None) -> Validat
     # Run pytest with coverage
     errors: List[str] = []
     cov = 0.0
-    pytest_returncode = -1 # Initialize with a failure code
-    process_output = "Pytest execution did not complete." # Default message
+    pytest_returncode = -1  # Initialize with a failure code
+    process_output = "Pytest execution did not complete."  # Default message
 
     try:
         # Get the current environment
         env = os.environ.copy()
-        
+
         # Strip pytest-cov coordination variables from the environment
-        for var in ("COVERAGE_FILE", "COV_CORE_SOURCE",
-                    "COV_CORE_CONFIG", "COV_CORE_DATAFILE"):
+        for var in (
+            "COVERAGE_FILE",
+            "COV_CORE_SOURCE",
+            "COV_CORE_CONFIG",
+            "COV_CORE_DATAFILE",
+            "COVERAGE_PROCESS_START",
+        ):
             env.pop(var, None)
-        
+
         # Prepend the artefact directory to PYTHONPATH
         # This ensures 'from tool import ...' works reliably for coverage tracking
-        env['PYTHONPATH'] = artefact_dir + os.pathsep + env.get('PYTHONPATH', '')
+        env["PYTHONPATH"] = artefact_dir + os.pathsep + env.get("PYTHONPATH", "")
 
         # Run pytest in artefact_dir with coverage for all files and disable warnings
         pytest_command = [
-            "pytest", "--maxfail=1", "--disable-warnings",
+            "pytest",
+            "--maxfail=1",
+            "--disable-warnings",
         ]
         # Conditionally add coverage arguments
-        is_edge_case = tool_id.startswith('edge')
+        is_edge_case = tool_id.startswith("edge")
         if not is_edge_case:
-            pytest_command.extend(["--cov=.", "--cov-report", "term", "--cov-report", "xml"])
+            cov_config = Path(__file__).resolve().parents[2] / "pyproject.toml"
+            pytest_command.extend(
+                [
+                    "--cov=.",
+                    "--cov-report",
+                    "term",
+                    "--cov-report",
+                    "xml",
+                    "--cov-config",
+                    str(cov_config),
+                ]
+            )
 
         pytest_command.append(test_file)
 
         result = subprocess.run(
             pytest_command,
-            cwd=artefact_dir, capture_output=True, text=True, timeout=30, check=False, env=env # Pass modified env
+            cwd=artefact_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=env,  # Pass modified env
         )
 
         pytest_returncode = result.returncode
-        process_output = f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}" # Store full output for logging
-        logger.debug(f"Pytest run for {tool_id} completed with code {pytest_returncode}.\n{process_output}")
+        process_output = f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"  # Store full output for logging
+        logger.debug(
+            f"Pytest run for {tool_id} completed with code {pytest_returncode}.\n{process_output}"
+        )
 
         if pytest_returncode != 0:
             # filter benign warnings that arrive on STDERR
             warn_filtered = [
-                ln for ln in (result.stderr or result.stdout or f"Pytest failed with return code {pytest_returncode}").splitlines()
+                ln
+                for ln in (
+                    result.stderr
+                    or result.stdout
+                    or f"Pytest failed with return code {pytest_returncode}"
+                ).splitlines()
                 if "PytestDeprecationWarning" not in ln
             ]
             if warn_filtered:
@@ -85,9 +121,11 @@ def validate_generated_tool(tool: GeneratedTool, tool_id: str = None) -> Validat
 
         # --- Coverage Parsing ---
         # Always try to parse coverage, even if tests failed, as the file might exist
-        cov = 0.0 # Default coverage to 0
+        cov = 0.0  # Default coverage to 0
         cov_xml = os.path.join(artefact_dir, "coverage.xml")
-        if not is_edge_case and os.path.exists(cov_xml): # Only parse if not edge case and file exists
+        if not is_edge_case and os.path.exists(
+            cov_xml
+        ):  # Only parse if not edge case and file exists
             try:
                 tree = ET.parse(cov_xml)
                 root = tree.getroot()
@@ -98,26 +136,32 @@ def validate_generated_tool(tool: GeneratedTool, tool_id: str = None) -> Validat
                 errors.append(f"Failed to parse coverage.xml: {xml_e}")
                 cov = 0.0
         elif not is_edge_case:
-             # Only log warning if tests actually passed but coverage file is missing (and not an edge case)
-             if pytest_returncode == 0:
-                 logger.warning(f"coverage.xml not found for {tool_id} after successful pytest run.")
-                 errors.append("Coverage file (coverage.xml) not found.")
-             cov = 0.0
+            # Only log warning if tests actually passed but coverage file is missing (and not an edge case)
+            if pytest_returncode == 0:
+                logger.warning(
+                    f"coverage.xml not found for {tool_id} after successful pytest run."
+                )
+                errors.append("Coverage file (coverage.xml) not found.")
+            cov = 0.0
 
     except subprocess.TimeoutExpired:
         errors.append("Pytest validation timed out after 30 seconds.")
         logger.error(f"Pytest validation timed out for {tool_id}.")
-        pytest_returncode = -1 # Ensure failure state
+        pytest_returncode = -1  # Ensure failure state
         cov = 0.0
     except Exception as e:
         errors.append(f"Subprocess execution failed: {str(e)}")
-        logger.error(f"Error running pytest subprocess for {tool_id}: {e}", exc_info=True)
-        pytest_returncode = -1 # Ensure failure state
+        logger.error(
+            f"Error running pytest subprocess for {tool_id}: {e}", exc_info=True
+        )
+        pytest_returncode = -1  # Ensure failure state
         cov = 0.0
 
     # --- Success Determination ---
     # Success depends ONLY on return code being 0 and coverage threshold being met (if applicable)
-    coverage_threshold_met = is_edge_case or (cov >= COVERAGE_FAIL) # Edge cases don't need coverage
+    coverage_threshold_met = is_edge_case or (
+        cov >= COVERAGE_FAIL
+    )  # Edge cases don't need coverage
 
     # For edge cases, accept any pytest return code
     pytest_passed_or_edge_case_interrupted = (pytest_returncode == 0) or is_edge_case
@@ -130,6 +174,8 @@ def validate_generated_tool(tool: GeneratedTool, tool_id: str = None) -> Validat
 
     # Log detailed info if validation failed
     if not success:
-        logger.error(f"Validation failed for {tool_id}. Success: {success}, Return Code: {pytest_returncode}, Coverage: {cov:.2f}%, Errors: {errors}\nPytest Output:\n{process_output}")
+        logger.error(
+            f"Validation failed for {tool_id}. Success: {success}, Return Code: {pytest_returncode}, Coverage: {cov:.2f}%, Errors: {errors}\nPytest Output:\n{process_output}"
+        )
 
     return ValidationResult(success=success, errors=errors, coverage=cov)

--- a/tests/test_bundle_validator.py
+++ b/tests/test_bundle_validator.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from meta_agent.bundle_generator import BundleGenerator
+from meta_agent.bundle_validator import BundleValidator
+
+
+def create_sample_bundle(tmp_path: Path) -> Path:
+    gen = BundleGenerator(tmp_path)
+    gen.generate(
+        agent_code="def main():\n    return 'ok'",
+        tests={
+            "test_main.py": "from agent import main\n\ndef test_main():\n    assert main() == 'ok'",
+        },
+        requirements=["pytest==8.0.0"],
+        readme="# Sample",
+    )
+    return tmp_path
+
+
+def test_bundle_validator_success(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is True
+    assert result.errors == []
+
+
+def test_bundle_validator_checksum_failure(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "agent.py").write_text("broken")
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("checksum mismatch" in e for e in result.errors)
+
+
+def test_bundle_validator_unpinned_requirement(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "requirements.txt").write_text("pytest>=8")
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("unpinned requirement" in e for e in result.errors)
+
+
+def test_bundle_validator_test_failure(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "tests" / "test_main.py").write_text(
+        "def test_fail():\n    assert False"
+    )
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("tests failed" in e for e in result.errors)


### PR DESCRIPTION
## Summary
- prevent coverage env contamination when running tool validation
- ensure branch coverage config is used in subprocess
- test environment cleanup for coverage variables

## Testing
- `ruff check src/meta_agent/validation.py tests/unit/test_validation.py`
- `black --check src/meta_agent/validation.py tests/unit/test_validation.py`
- `mypy src/meta_agent` *(fails: Cannot find implementation or library stub for module named "jinja2")*
- `pyright` *(fails: "Agent" is unknown import symbol)*
- `pytest tests/unit/test_validation.py -q`
