### PR TITLE
fix: run bundle tests with clean env

### DIFF
--- a/src/meta_agent/bundle_validator.py
+++ b/src/meta_agent/bundle_validator.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import py_compile
+import subprocess
+from pathlib import Path
+from typing import List
+
+from .models import BundleMetadata
+from .models.validation_result import ValidationResult
+
+
+class BundleValidator:
+    """Validate the contents of a generated agent bundle."""
+
+    def __init__(self, bundle_dir: str | Path) -> None:
+        self.bundle_dir = Path(bundle_dir)
+
+    def _load_metadata(self) -> BundleMetadata:
+        with open(self.bundle_dir / "bundle.json", encoding="utf-8") as f:
+            data = json.load(f)
+        return BundleMetadata(**data)
+
+    def _validate_checksums(self, metadata: BundleMetadata, errors: List[str]) -> None:
+        checksums = metadata.custom.get("checksums", {})
+        for rel, expected in checksums.items():
+            path = self.bundle_dir / rel
+            if not path.exists():
+                errors.append(f"missing file {rel}")
+                continue
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            if digest != expected:
+                errors.append(f"checksum mismatch for {rel}")
+
+    def _validate_requirements(self, errors: List[str]) -> None:
+        req_path = self.bundle_dir / "requirements.txt"
+        if not req_path.exists():
+            errors.append("requirements.txt missing")
+            return
+        for line in req_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "==" not in line:
+                errors.append(f"unpinned requirement: {line}")
+
+    def _validate_agent(self, errors: List[str]) -> None:
+        try:
+            py_compile.compile(str(self.bundle_dir / "agent.py"), doraise=True)
+        except py_compile.PyCompileError as exc:
+            errors.append(f"agent.py failed to compile: {exc.msg}")
+
+    def _run_tests(self, errors: List[str]) -> None:
+        env = os.environ.copy()
+        for var in (
+            "COVERAGE_FILE",
+            "COVERAGE_PROCESS_START",
+            "COV_CORE_SOURCE",
+            "COV_CORE_CONFIG",
+            "COV_CORE_DATAFILE",
+        ):
+            env.pop(var, None)
+
+        env["PYTHONPATH"] = (
+            str(self.bundle_dir) + os.pathsep + env.get("PYTHONPATH", "")
+        )
+
+        result = subprocess.run(
+            ["pytest", "-x", "-c", "/dev/null"],
+            cwd=self.bundle_dir,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if result.returncode != 0:
+            errors.append("tests failed")
+
+    def validate(self) -> ValidationResult:
+        errors: List[str] = []
+        try:
+            metadata = self._load_metadata()
+        except Exception as exc:  # pragma: no cover - invalid json path rare
+            errors.append(f"invalid bundle metadata: {exc}")
+            return ValidationResult(success=False, errors=errors, coverage=0.0)
+
+        self._validate_checksums(metadata, errors)
+        self._validate_requirements(errors)
+        self._validate_agent(errors)
+
+        self._run_tests(errors)
+
+        success = not errors
+        return ValidationResult(success=success, errors=errors, coverage=0.0)

--- a/tests/test_bundle_validator.py
+++ b/tests/test_bundle_validator.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from meta_agent.bundle_generator import BundleGenerator
+from meta_agent.bundle_validator import BundleValidator
+
+
+def create_sample_bundle(tmp_path: Path) -> Path:
+    gen = BundleGenerator(tmp_path)
+    gen.generate(
+        agent_code="def main():\n    return 'ok'",
+        tests={
+            "test_main.py": "from agent import main\n\ndef test_main():\n    assert main() == 'ok'",
+        },
+        requirements=["pytest==8.0.0"],
+        readme="# Sample",
+    )
+    return tmp_path
+
+
+def test_bundle_validator_success(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is True
+    assert result.errors == []
+
+
+def test_bundle_validator_checksum_failure(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "agent.py").write_text("broken")
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("checksum mismatch" in e for e in result.errors)
+
+
+def test_bundle_validator_unpinned_requirement(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "requirements.txt").write_text("pytest>=8")
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("unpinned requirement" in e for e in result.errors)
+
+
+def test_bundle_validator_test_failure(tmp_path: Path) -> None:
+    bundle_dir = create_sample_bundle(tmp_path)
+    (bundle_dir / "tests" / "test_main.py").write_text(
+        "def test_fail():\n    assert False"
+    )
+    validator = BundleValidator(bundle_dir)
+    result = validator.validate()
+    assert result.success is False
+    assert any("tests failed" in e for e in result.errors)


### PR DESCRIPTION
## Summary
- run bundle tests even when earlier checks fail
- strip coverage env vars before running bundle tests
- ensure bundle tests ignore repo pytest config

## Testing
- `ruff check src/meta_agent/bundle_validator.py tests/test_bundle_validator.py`
- `black --check src/meta_agent/bundle_validator.py tests/test_bundle_validator.py`
- `mypy src/meta_agent` *(fails: Cannot find implementation or library stub for module named "agents")*
- `pyright` *(fails: "Agent" is unknown import symbol)*
- `pytest tests/test_bundle_validator.py -q`
- `pytest -q` *(fails: 25 errors during collection: missing dependencies)*