### PR TITLE
feat: add bundle API and hooks

### DIFF
--- a/docs/bundle_layout.md
+++ b/docs/bundle_layout.md
@@ -46,3 +46,35 @@ reading the metadata should ignore unrecognised fields while still enforcing the
 presence of `schema_version`.
 You can supply additional top-level keys using the `metadata_fields` argument
 when generating a bundle.
+
+## Bundle API
+
+Use the :class:`meta_agent.bundle.Bundle` helper to load and introspect bundles.
+It parses ``bundle.json`` and provides convenience methods to list files and
+access metadata.
+
+```python
+from meta_agent import Bundle
+
+bundle = Bundle("path/to/bundle")
+print(bundle.metadata.meta_agent_version)
+print(bundle.list_files())
+```
+
+## Extensibility Hooks
+
+``BundleGenerator.generate`` accepts optional ``pre_hook`` and ``post_hook``
+callables. The pre hook runs before any files are created; the post hook runs
+after ``bundle.json`` is written and Git operations complete. Hooks receive the
+bundle directory path, and the post hook also receives the loaded
+``BundleMetadata`` object.
+
+```python
+def add_marker(path: Path) -> None:
+    (path / "MARKER").write_text("generated")
+
+def report(path: Path, meta: BundleMetadata) -> None:
+    print("created", meta.meta_agent_version)
+
+gen.generate(agent_code="print('x')", pre_hook=add_marker, post_hook=report)
+```

--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 
 import builtins
 
+from .bundle import Bundle
+
 # Expose `patch` globally for tests that forget to import it.
 try:
     # Only add if it hasn't been defined elsewhere to avoid clobbering.
     if not hasattr(builtins, "patch"):
-        from unittest.mock import patch as _patch  # Lazy import to avoid unnecessary overhead.
+        from unittest.mock import (
+            patch as _patch,
+        )  # Lazy import to avoid unnecessary overhead.
 
         builtins.patch = _patch  # type: ignore[attr-defined]
 except Exception:  # pragma: no cover
@@ -24,3 +28,5 @@ except Exception:  # pragma: no cover
     # any unexpected error silently – tests will fail loudly if they rely
     # on it and something went wrong here.
     pass
+
+__all__ = ["Bundle"]

--- a/src/meta_agent/bundle.py
+++ b/src/meta_agent/bundle.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .models import BundleMetadata
+
+
+class Bundle:
+    """Helper for loading and introspecting generated bundles."""
+
+    def __init__(self, bundle_dir: str | Path) -> None:
+        self.bundle_dir = Path(bundle_dir)
+        self._metadata: BundleMetadata | None = None
+
+    @property
+    def metadata(self) -> BundleMetadata:
+        if self._metadata is None:
+            self.refresh_metadata()
+        assert self._metadata is not None
+        return self._metadata
+
+    def refresh_metadata(self) -> None:
+        with open(self.bundle_dir / "bundle.json", encoding="utf-8") as f:
+            data = json.load(f)
+        self._metadata = BundleMetadata(**data)
+
+    def list_files(self) -> List[str]:
+        files: List[str] = []
+        for path in self.bundle_dir.rglob("*"):
+            if (
+                path.is_file()
+                and path.name != "bundle.json"
+                and ".git" not in path.parts
+            ):
+                files.append(str(path.relative_to(self.bundle_dir)))
+        return files
+
+    def read_text(self, relative: str | Path) -> str:
+        return (self.bundle_dir / relative).read_text(encoding="utf-8")
+
+    @property
+    def checksums(self) -> Dict[str, str]:
+        return dict(self.metadata.custom.get("checksums", {}))

--- a/src/meta_agent/bundle_generator.py
+++ b/src/meta_agent/bundle_generator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import hashlib
 from pathlib import Path
-from typing import Mapping, Sequence, Optional, Any
+from typing import Mapping, Sequence, Optional, Any, Callable
 
 from .models import BundleMetadata
 from .git_utils import GitManager
@@ -36,8 +36,13 @@ class BundleGenerator:
         *,
         init_git: bool = False,
         git_remote: Optional[str] = None,
+        pre_hook: Optional[Callable[[Path], None]] = None,
+        post_hook: Optional[Callable[[Path, BundleMetadata], None]] = None,
     ) -> BundleMetadata:
         """Generate bundle files and return metadata."""
+
+        if pre_hook:
+            pre_hook(self.bundle_dir)
 
         checksums: dict[str, str] = {}
 
@@ -99,5 +104,8 @@ class BundleGenerator:
                     else metadata.json()  # type: ignore[attr-defined]
                 )
                 json.dump(json.loads(dump_json), f, indent=2)
+
+        if post_hook:
+            post_hook(self.bundle_dir, metadata)
 
         return metadata

--- a/tests/test_bundle_api.py
+++ b/tests/test_bundle_api.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from meta_agent.bundle_generator import BundleGenerator
+from meta_agent.bundle import Bundle
+
+
+def test_bundle_load_and_list_files(tmp_path: Path) -> None:
+    gen = BundleGenerator(tmp_path)
+    gen.generate(agent_code="print('hi')")
+
+    b = Bundle(tmp_path)
+    assert b.metadata.schema_version
+    files = b.list_files()
+    assert "agent.py" in files
+    assert b.read_text("agent.py").strip() == "print('hi')"
+
+
+def test_bundle_generator_hooks(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def pre(path: Path) -> None:
+        calls.append("pre")
+
+    def post(path: Path, meta) -> None:
+        calls.append("post")
+
+    gen = BundleGenerator(tmp_path)
+    gen.generate(agent_code="print('x')", pre_hook=pre, post_hook=post)
+
+    assert calls == ["pre", "post"]


### PR DESCRIPTION
## Summary
- expose new `Bundle` helper for loading bundle metadata
- support `pre_hook` and `post_hook` in `BundleGenerator`
- document bundle API and hooks
- test bundle API and hook behaviour

## Testing
- `ruff check src/meta_agent/bundle.py src/meta_agent/bundle_generator.py src/meta_agent/__init__.py tests/test_bundle_api.py`
- `mypy src/meta_agent/bundle.py src/meta_agent/bundle_generator.py src/meta_agent/__init__.py tests/test_bundle_api.py`
- `pyright src/meta_agent/bundle.py src/meta_agent/bundle_generator.py src/meta_agent/__init__.py tests/test_bundle_api.py`
- `pytest tests/test_bundle_api.py -q`
