### PR TITLE
feat: add telemetry api client

### DIFF
--- a/pytest_asyncio.py
+++ b/pytest_asyncio.py
@@ -1,10 +1,8 @@
 import asyncio
-import pytest
+
 
 def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "asyncio: mark test as running in an event loop"
-    )
+    config.addinivalue_line("markers", "asyncio: mark test as running in an event loop")
 
 
 def pytest_pyfunc_call(pyfuncitem):

--- a/src/meta_agent/services/__init__.py
+++ b/src/meta_agent/services/__init__.py
@@ -7,5 +7,13 @@ and provide functionality to other components of the meta_agent system.
 
 from .llm_service import LLMService
 from .guardrail_router import GuardrailModelRouter, ModelAdapter, LLMModelAdapter
+from .telemetry_client import TelemetryAPIClient, EndpointConfig
 
-__all__ = ["LLMService", "GuardrailModelRouter", "ModelAdapter", "LLMModelAdapter"]
+__all__ = [
+    "LLMService",
+    "GuardrailModelRouter",
+    "ModelAdapter",
+    "LLMModelAdapter",
+    "TelemetryAPIClient",
+    "EndpointConfig",
+]

--- a/src/meta_agent/services/telemetry_client.py
+++ b/src/meta_agent/services/telemetry_client.py
@@ -1,0 +1,116 @@
+"""Telemetry API client and tracing integration utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EndpointConfig:
+    """Configuration for a telemetry API endpoint."""
+
+    url: str
+    auth_token: Optional[str] = None
+    headers: Dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.auth_token:
+            self.headers["Authorization"] = f"Bearer {self.auth_token}"
+        self.headers.setdefault("Content-Type", "application/json")
+
+
+class TelemetryAPIClient:
+    """Simple async client for posting telemetry data to multiple endpoints.
+
+    Parameters
+    ----------
+    endpoints:
+        Mapping of endpoint names to :class:`EndpointConfig` objects. Each
+        endpoint must specify the full URL for posting telemetry data.
+    rate_limit:
+        Maximum number of concurrent requests allowed. This acts as a basic
+        rate limiter when sending many events quickly.
+    timeout:
+        Request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        endpoints: Dict[str, EndpointConfig],
+        *,
+        rate_limit: int = 5,
+        timeout: int = 10,
+    ) -> None:
+        if not endpoints:
+            raise ValueError("At least one endpoint must be configured")
+        self.endpoints = endpoints
+        self.timeout = timeout
+        self._sem = asyncio.Semaphore(rate_limit)
+        self._session = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(limit=None)
+        )
+
+    async def send(self, name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Post ``payload`` to the endpoint identified by ``name``."""
+        if name not in self.endpoints:
+            raise ValueError(f"Unknown endpoint '{name}'")
+        cfg = self.endpoints[name]
+        async with self._sem:
+            async with self._session.post(
+                cfg.url,
+                json=payload,
+                headers=cfg.headers,
+                timeout=self.timeout,
+            ) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise ValueError(f"API error: {resp.status} - {text}")
+                return await resp.json()
+
+    async def close(self) -> None:
+        """Close the underlying HTTP session."""
+        await self._session.close()
+
+    # --- Runner integration -------------------------------------------------
+
+    def attach_runner(self, runner_cls: Any, endpoint: str = "traces") -> None:
+        """Patch ``runner_cls.run`` to send span data to ``endpoint``.
+
+        The patched ``run`` method forwards all arguments to the original
+        implementation, awaits the result, and if the result object exposes a
+        ``span_graph``/``spans``/``trace`` attribute, it will be posted to the
+        configured telemetry endpoint using :meth:`send`.
+        """
+
+        orig_run = getattr(runner_cls, "run")
+
+        async def wrapped_run(*args: Any, **kwargs: Any) -> Any:
+            result = await orig_run(*args, **kwargs)
+            span_data = (
+                getattr(result, "span_graph", None)
+                or getattr(result, "spans", None)
+                or getattr(result, "trace", None)
+            )
+            if span_data is not None:
+                try:
+                    await self.send(endpoint, span_data)  # type: ignore[arg-type]
+                except Exception as exc:  # pragma: no cover - log only
+                    logger.error("Failed to send telemetry: %s", exc)
+            return result
+
+        setattr(runner_cls, "run", wrapped_run)
+        runner_cls._meta_agent_orig_run = orig_run  # type: ignore[attr-defined]
+
+    def detach_runner(self, runner_cls: Any) -> None:
+        """Restore ``runner_cls.run`` if it was patched by :meth:`attach_runner`."""
+        orig = getattr(runner_cls, "_meta_agent_orig_run", None)
+        if orig:
+            setattr(runner_cls, "run", orig)
+            delattr(runner_cls, "_meta_agent_orig_run")

--- a/tests/unit/test_telemetry_client.py
+++ b/tests/unit/test_telemetry_client.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from meta_agent.services.telemetry_client import TelemetryAPIClient, EndpointConfig
+
+
+@pytest.fixture
+async def telemetry_client():
+    with patch("aiohttp.ClientSession") as mock_session:
+        response = AsyncMock()
+        response.status = 200
+        response.json = AsyncMock(return_value={"ok": True})
+        cm = AsyncMock()
+        cm.__aenter__.return_value = response
+        mock_session.return_value.post.return_value = cm
+        client = TelemetryAPIClient({"trace": EndpointConfig("http://example.com")})
+        try:
+            yield client
+        finally:
+            await client.close()
+
+
+@pytest.mark.asyncio
+async def test_send_success(telemetry_client):
+    result = await telemetry_client.send("trace", {"data": 1})
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_send_http_error():
+    with patch("aiohttp.ClientSession") as mock_session:
+        resp = AsyncMock()
+        resp.status = 500
+        resp.text = AsyncMock(return_value="bad")
+        cm = AsyncMock()
+        cm.__aenter__.return_value = resp
+        mock_session.return_value.post.return_value = cm
+        client = TelemetryAPIClient({"trace": EndpointConfig("http://example.com")})
+        with pytest.raises(ValueError):
+            await client.send("trace", {"d": 1})
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_runner(monkeypatch):
+    # Fake runner class
+    class FakeRunner:
+        async def run(self, *_, **__):
+            class Res:
+                span_graph = {"span": 1}
+
+            return Res()
+
+    client = TelemetryAPIClient({"trace": EndpointConfig("http://example.com")})
+    send_mock = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(client, "send", send_mock)
+
+    client.attach_runner(FakeRunner, "trace")
+    res = await FakeRunner().run(None)
+    assert hasattr(res, "span_graph")
+    send_mock.assert_awaited_once_with("trace", {"span": 1})
+    await client.close()


### PR DESCRIPTION
## Summary
- create TelemetryAPIClient for sending trace data and hooking into Runner
- expose client via `services.__init__`
- add unit tests for the client
- clean up pytest asyncio plugin

## Testing
- `ruff check .` *(fails: E402 and F401 in existing files)*
- `black --check src/meta_agent/services/telemetry_client.py tests/unit/test_telemetry_client.py pytest_asyncio.py`
- `mypy src/meta_agent` *(fails: missing type stubs)*
- `pyright` *(fails: numerous type errors)*
- `pytest -v tests` *(fails: 25 errors during collection)*
