### PR TITLE
feat: add telemetry collector and CLI summary

### DIFF
--- a/src/meta_agent/cli/main.py
+++ b/src/meta_agent/cli/main.py
@@ -17,6 +17,7 @@ from meta_agent.planning_engine import PlanningEngine
 from meta_agent.sub_agent_manager import SubAgentManager
 from meta_agent.registry import ToolRegistry
 from meta_agent.tool_designer import ToolDesignerAgent
+from meta_agent.telemetry import TelemetryCollector
 
 # TODO: Import logging setup from utils
 
@@ -46,6 +47,7 @@ async def generate(spec_file: Path | None, spec_text: str | None):
         sys.exit(1)
 
     spec: SpecSchema | None = None
+    telemetry = TelemetryCollector()
 
     try:
         if spec_file:
@@ -111,9 +113,12 @@ async def generate(spec_file: Path | None, spec_text: str | None):
             click.echo("\nStarting agent generation orchestration...")
             # Convert Pydantic model to dict for the orchestrator
             spec_dict = spec.model_dump(exclude_unset=True)
+            telemetry.start_timer()
             results = await orchestrator.run(specification=spec_dict)
+            telemetry.stop_timer()
             click.echo("\nOrchestration finished.")
             click.echo(f"Results: {json.dumps(results, indent=2)}")
+            click.echo(telemetry.summary_line())
 
         else:
             # This case should ideally not be reached due to prior checks/errors

--- a/src/meta_agent/services/__init__.py
+++ b/src/meta_agent/services/__init__.py
@@ -16,6 +16,7 @@ except Exception:  # pragma: no cover - fallback when optional deps missing
     GuardrailModelRouter = ModelAdapter = LLMModelAdapter = None  # type: ignore[misc]
 
 from .telemetry_client import TelemetryAPIClient, EndpointConfig
+from meta_agent.telemetry import TelemetryCollector
 
 __all__ = [
     "LLMService",
@@ -24,4 +25,5 @@ __all__ = [
     "LLMModelAdapter",
     "TelemetryAPIClient",
     "EndpointConfig",
+    "TelemetryCollector",
 ]

--- a/src/meta_agent/telemetry.py
+++ b/src/meta_agent/telemetry.py
@@ -1,0 +1,55 @@
+import time
+import logging
+from typing import Dict, Optional
+
+
+class TelemetryCollector:
+    """Collect basic usage metrics for a generation run."""
+
+    COST_TABLE: Dict[str, float] = {
+        "o3": 0.01,
+        "o4-mini-high": 0.02,
+        "gpt-4o": 0.03,
+        "default": 0.01,
+    }
+
+    def __init__(self, cost_cap: float = 0.5) -> None:
+        self.cost_cap = cost_cap
+        self.token_count = 0
+        self.cost = 0.0
+        self.guardrail_hits = 0
+        self.latency = 0.0
+        self._start: Optional[float] = None
+        self.logger = logging.getLogger(__name__)
+
+    # --- Timing -----------------------------------------------------
+    def start_timer(self) -> None:
+        """Start the latency timer."""
+        self._start = time.perf_counter()
+
+    def stop_timer(self) -> None:
+        """Stop the latency timer and accumulate duration."""
+        if self._start is not None:
+            self.latency += time.perf_counter() - self._start
+            self._start = None
+
+    # --- Usage ------------------------------------------------------
+    def add_usage(self, prompt_tokens: int, response_tokens: int, model: str = "default") -> None:
+        """Record token usage and update cost."""
+        tokens = prompt_tokens + response_tokens
+        self.token_count += tokens
+        rate = self.COST_TABLE.get(model, self.COST_TABLE["default"])
+        self.cost += rate * tokens / 1000.0
+        if self.cost >= self.cost_cap:
+            self.logger.warning("Cost cap exceeded: $%.2f >= $%.2f", self.cost, self.cost_cap)
+            raise RuntimeError("cost cap exceeded")
+
+    # --- Summary ----------------------------------------------------
+    def summary_line(self) -> str:
+        """Return a one-line summary of collected metrics."""
+        return (
+            f"Telemetry: cost=${self.cost:.2f} "
+            f"tokens={self.token_count} "
+            f"latency={self.latency:.2f}s "
+            f"guardrails={self.guardrail_hits}"
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,8 @@ def test_cli_generate_spec_file_json(runner, sample_json_file):
     assert "Orchestration finished." in result.output
     # Optionally, check for status: success in the final JSON output
     assert '"status": "simulated_success"' in result.output
+    assert "Telemetry:" in result.output
+    assert "Telemetry:" in result.output
 
 def test_cli_generate_spec_file_yaml(runner, sample_yaml_file):
     """Test successful generation using a YAML spec file."""

--- a/tests/unit/test_telemetry_collector.py
+++ b/tests/unit/test_telemetry_collector.py
@@ -1,0 +1,25 @@
+import pytest
+from meta_agent.telemetry import TelemetryCollector
+
+
+def test_usage_accumulation():
+    t = TelemetryCollector(cost_cap=1.0)
+    t.add_usage(500, 500, model="o3")
+    assert t.token_count == 1000
+    assert pytest.approx(t.cost, 0.0001) == 0.01
+
+
+def test_cost_cap_enforced():
+    t = TelemetryCollector(cost_cap=0.001)
+    with pytest.raises(RuntimeError):
+        t.add_usage(1000, 0, model="o3")
+
+
+def test_summary_line():
+    t = TelemetryCollector()
+    t.start_timer()
+    t.stop_timer()
+    line = t.summary_line()
+    assert "Telemetry:" in line
+    assert "cost=$" in line
+    assert "tokens=0" in line


### PR DESCRIPTION
## Notes
- implement `TelemetryCollector` for basic usage tracking
- show telemetry summary after `generate` command completes
- expose collector from services package
- add unit tests
- check CLI output for telemetry summary

## Testing
- `ruff check .` *(fails: E402, F401 across repo)*
- `black --check .` *(fails: many files would be reformatted)*
- `mypy src/meta_agent` *(fails: several missing modules)*
- `pyright` *(fails: various type errors)*
- `pytest -q` *(fails: ModuleNotFoundError for jinja2, backoff, agents)*