### PR TITLE
feat: add telemetry database

### DIFF
--- a/src/meta_agent/cli/main.py
+++ b/src/meta_agent/cli/main.py
@@ -18,13 +18,23 @@ from meta_agent.sub_agent_manager import SubAgentManager
 from meta_agent.registry import ToolRegistry
 from meta_agent.tool_designer import ToolDesignerAgent
 from meta_agent.telemetry import TelemetryCollector
+from meta_agent.telemetry_db import TelemetryDB
+import tempfile
 
 # TODO: Import logging setup from utils
 
 
 @click.group()
-def cli():
+@click.option(
+    "--no-sensitive-logs",
+    is_flag=True,
+    help="Exclude sensitive data from traces and telemetry.",
+)
+@click.pass_context
+def cli(ctx: click.Context, no_sensitive_logs: bool) -> None:
     """Meta-Agent: A tool to generate AI agent code from specifications."""
+    ctx.ensure_object(dict)
+    ctx.obj["include_sensitive"] = not no_sensitive_logs
     # TODO: Configure logging
     pass
 
@@ -47,7 +57,12 @@ async def generate(spec_file: Path | None, spec_text: str | None):
         sys.exit(1)
 
     spec: SpecSchema | None = None
-    telemetry = TelemetryCollector()
+    include_sensitive: bool = click.get_current_context().obj.get(
+        "include_sensitive", True
+    )
+    db_path = Path(tempfile.gettempdir()) / "meta_agent_telemetry.db"
+    db = TelemetryDB(db_path)
+    telemetry = TelemetryCollector(db=db, include_sensitive=include_sensitive)
 
     try:
         if spec_file:
@@ -119,6 +134,7 @@ async def generate(spec_file: Path | None, spec_text: str | None):
             click.echo("\nOrchestration finished.")
             click.echo(f"Results: {json.dumps(results, indent=2)}")
             click.echo(telemetry.summary_line())
+            db.close()
 
         else:
             # This case should ideally not be reached due to prior checks/errors

--- a/src/meta_agent/services/__init__.py
+++ b/src/meta_agent/services/__init__.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover - fallback when optional deps missing
 
 from .telemetry_client import TelemetryAPIClient, EndpointConfig
 from meta_agent.telemetry import TelemetryCollector
+from meta_agent.telemetry_db import TelemetryDB
 
 __all__ = [
     "LLMService",
@@ -26,4 +27,5 @@ __all__ = [
     "TelemetryAPIClient",
     "EndpointConfig",
     "TelemetryCollector",
+    "TelemetryDB",
 ]

--- a/src/meta_agent/telemetry.py
+++ b/src/meta_agent/telemetry.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import time
 import logging
 from typing import Dict, Optional
+
+from .telemetry_db import TelemetryDB
 
 
 class TelemetryCollector:
@@ -13,7 +17,13 @@ class TelemetryCollector:
         "default": 0.01,
     }
 
-    def __init__(self, cost_cap: float = 0.5) -> None:
+    def __init__(
+        self,
+        cost_cap: float = 0.5,
+        *,
+        db: TelemetryDB | None = None,
+        include_sensitive: bool = True,
+    ) -> None:
         self.cost_cap = cost_cap
         self.token_count = 0
         self.cost = 0.0
@@ -21,6 +31,8 @@ class TelemetryCollector:
         self.latency = 0.0
         self._start: Optional[float] = None
         self.logger = logging.getLogger(__name__)
+        self.db = db
+        self.include_sensitive = include_sensitive
 
     # --- Timing -----------------------------------------------------
     def start_timer(self) -> None:
@@ -32,24 +44,38 @@ class TelemetryCollector:
         if self._start is not None:
             self.latency += time.perf_counter() - self._start
             self._start = None
+        if self.db:
+            self.db.record(
+                self.token_count,
+                self.cost,
+                self.latency,
+                self.guardrail_hits,
+            )
 
     # --- Usage ------------------------------------------------------
-    def add_usage(self, prompt_tokens: int, response_tokens: int, model: str = "default") -> None:
+    def add_usage(
+        self, prompt_tokens: int, response_tokens: int, model: str = "default"
+    ) -> None:
         """Record token usage and update cost."""
         tokens = prompt_tokens + response_tokens
         self.token_count += tokens
         rate = self.COST_TABLE.get(model, self.COST_TABLE["default"])
         self.cost += rate * tokens / 1000.0
         if self.cost >= self.cost_cap:
-            self.logger.warning("Cost cap exceeded: $%.2f >= $%.2f", self.cost, self.cost_cap)
+            self.logger.warning(
+                "Cost cap exceeded: $%.2f >= $%.2f", self.cost, self.cost_cap
+            )
             raise RuntimeError("cost cap exceeded")
 
     # --- Summary ----------------------------------------------------
     def summary_line(self) -> str:
         """Return a one-line summary of collected metrics."""
+        cost = f"${self.cost:.2f}" if self.include_sensitive else "<redacted>"
+        tokens = str(self.token_count) if self.include_sensitive else "<redacted>"
         return (
-            f"Telemetry: cost=${self.cost:.2f} "
-            f"tokens={self.token_count} "
+            "Telemetry: "
+            f"cost={cost} "
+            f"tokens={tokens} "
             f"latency={self.latency:.2f}s "
             f"guardrails={self.guardrail_hits}"
         )

--- a/src/meta_agent/telemetry_db.py
+++ b/src/meta_agent/telemetry_db.py
@@ -1,0 +1,89 @@
+import sqlite3
+import json
+import gzip
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Dict, Optional
+
+
+class TelemetryDB:
+    """SQLite-backed storage for telemetry events."""
+
+    def __init__(
+        self, path: str | Path = "telemetry.db", retention_days: int = 30
+    ) -> None:
+        self.path = Path(path)
+        self.retention_days = retention_days
+        self.conn = sqlite3.connect(self.path)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS telemetry (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT NOT NULL,
+                tokens INTEGER,
+                cost REAL,
+                latency REAL,
+                guardrail_hits INTEGER
+            )
+            """
+        )
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    def record(
+        self, tokens: int, cost: float, latency: float, guardrail_hits: int
+    ) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO telemetry (timestamp, tokens, cost, latency, guardrail_hits) VALUES (?, ?, ?, ?, ?)",
+            (datetime.utcnow().isoformat(), tokens, cost, latency, guardrail_hits),
+        )
+        self.conn.commit()
+        self.purge_old()
+
+    def purge_old(self) -> None:
+        """Remove records older than ``retention_days``."""
+        if self.retention_days <= 0:
+            return
+        cutoff = datetime.utcnow() - timedelta(days=self.retention_days)
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM telemetry WHERE timestamp < ?", (cutoff.isoformat(),))
+        self.conn.commit()
+
+    def fetch_all(self) -> List[Dict[str, object]]:
+        cur = self.conn.cursor()
+        rows = cur.execute(
+            "SELECT timestamp, tokens, cost, latency, guardrail_hits FROM telemetry ORDER BY id"
+        ).fetchall()
+        return [
+            {
+                "timestamp": ts,
+                "tokens": tokens,
+                "cost": cost,
+                "latency": latency,
+                "guardrail_hits": hits,
+            }
+            for ts, tokens, cost, latency, hits in rows
+        ]
+
+    def verify(self) -> bool:
+        cur = self.conn.cursor()
+        res = cur.execute("PRAGMA integrity_check").fetchone()
+        return res[0] == "ok"
+
+    def archive(self, path: Optional[str] = None) -> str:
+        """Export all telemetry records to a gzipped JSON file."""
+        data = self.fetch_all()
+        if path is None:
+            name = datetime.utcnow().isoformat().replace(":", "").replace(".", "")
+            path = f"telemetry_{name}.json.gz"
+        with gzip.open(path, "wt", encoding="utf-8") as f:
+            json.dump(data, f)
+        return path
+
+    def close(self) -> None:
+        self.conn.close()

--- a/tests/unit/test_telemetry_db.py
+++ b/tests/unit/test_telemetry_db.py
@@ -1,0 +1,50 @@
+import json
+import gzip
+from pathlib import Path
+from meta_agent.telemetry_db import TelemetryDB
+from meta_agent.telemetry import TelemetryCollector
+
+
+def test_record_and_fetch(tmp_path):
+    db_path = tmp_path / "tele.db"
+    db = TelemetryDB(db_path, retention_days=1)
+    db.record(10, 0.1, 0.5, 0)
+    rows = db.fetch_all()
+    assert len(rows) == 1
+    assert rows[0]["tokens"] == 10
+    assert db.verify()
+    db.close()
+
+
+def test_purge_old(tmp_path):
+    db_path = tmp_path / "tele.db"
+    db = TelemetryDB(db_path, retention_days=1)
+    db.record(1, 0.01, 0.1, 0)
+    # update timestamp to old date
+    old_ts = "2000-01-01T00:00:00"
+    db.conn.execute("UPDATE telemetry SET timestamp=?", (old_ts,))
+    db.conn.commit()
+    db.purge_old()
+    assert db.fetch_all() == []
+    db.close()
+
+
+def test_archive(tmp_path):
+    db = TelemetryDB(tmp_path / "tele.db")
+    db.record(5, 0.02, 0.3, 1)
+    archive_path = db.archive(tmp_path / "out.gz")
+    with gzip.open(archive_path, "rt", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data[0]["guardrail_hits"] == 1
+    db.close()
+
+
+def test_collector_with_db(tmp_path):
+    db = TelemetryDB(tmp_path / "tele.db")
+    collector = TelemetryCollector(db=db, include_sensitive=False)
+    collector.start_timer()
+    collector.stop_timer()
+    line = collector.summary_line()
+    assert "<redacted>" in line
+    assert db.fetch_all()
+    db.close()


### PR DESCRIPTION
## Summary
- implement new `TelemetryDB` for SQLite-backed telemetry storage
- extend `TelemetryCollector` to store metrics and redact sensitive data
- add `--no-sensitive-logs` option to CLI and connect to telemetry storage
- expose `TelemetryDB` via services package
- test telemetry database functionality

## Testing
- `ruff check src/meta_agent/telemetry_db.py src/meta_agent/telemetry.py src/meta_agent/cli/main.py src/meta_agent/services/__init__.py tests/unit/test_telemetry_db.py`
- `black src/meta_agent/telemetry_db.py src/meta_agent/telemetry.py src/meta_agent/cli/main.py src/meta_agent/services/__init__.py tests/unit/test_telemetry_db.py`
- `mypy src/meta_agent/telemetry_db.py src/meta_agent/telemetry.py src/meta_agent/cli/main.py src/meta_agent/services/__init__.py --ignore-missing-imports` *(fails: various type errors in unrelated modules)*
- `pyright src/meta_agent/telemetry_db.py src/meta_agent/telemetry.py src/meta_agent/cli/main.py src/meta_agent/services/__init__.py` *(fails: `SpecSchema` missing `model_dump`)*
- `pytest -v tests` *(fails: errors during collection)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.