### PR TITLE
fix: restore telemetry and stub modules

### DIFF
--- a/src/aiohttp/__init__.py
+++ b/src/aiohttp/__init__.py
@@ -47,6 +47,3 @@ class Response:
         return ""
 
 
-class ClientError(Exception):
-    """Placeholder aiohttp ClientError."""
-

--- a/src/meta_agent/models/spec_schema.py
+++ b/src/meta_agent/models/spec_schema.py
@@ -1,4 +1,5 @@
 import json
+import os
 import yaml
 from pathlib import Path
 
@@ -56,8 +57,15 @@ class SpecSchema(BaseModel):
         """Creates a SpecSchema instance from a JSON string or file path."""
         data: Dict[str, Any]
         try:
-            if isinstance(json_input, Path) or Path(json_input).is_file():
-                file_path = Path(json_input)
+            file_path: Path | None = None
+            if isinstance(json_input, (str, Path)):
+                try:
+                    if os.path.isfile(str(json_input)):
+                        file_path = Path(json_input)
+                except OSError:
+                    file_path = None
+
+            if file_path:
                 if not file_path.exists():
                     raise FileNotFoundError(f"JSON file not found: {file_path}")
                 with file_path.open("r", encoding="utf-8") as f:
@@ -78,8 +86,15 @@ class SpecSchema(BaseModel):
         """Creates a SpecSchema instance from a YAML string or file path."""
         data: Dict[str, Any]
         try:
-            if isinstance(yaml_input, Path) or Path(yaml_input).is_file():
-                file_path = Path(yaml_input)
+            file_path: Path | None = None
+            if isinstance(yaml_input, (str, Path)):
+                try:
+                    if os.path.isfile(str(yaml_input)):
+                        file_path = Path(yaml_input)
+                except OSError:
+                    file_path = None
+
+            if file_path:
                 if not file_path.exists():
                     raise FileNotFoundError(f"YAML file not found: {file_path}")
                 with file_path.open("r", encoding="utf-8") as f:

--- a/src/meta_agent/validation.py
+++ b/src/meta_agent/validation.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import uuid
 import logging
+import sys
 import xml.etree.ElementTree as ET
 from typing import List
 from .models.validation_result import ValidationResult
@@ -67,6 +68,8 @@ def validate_generated_tool(
 
         # Run pytest in artefact_dir with coverage for all files and disable warnings
         pytest_command = [
+            sys.executable,
+            "-m",
             "pytest",
             "--maxfail=1",
             "--disable-warnings",


### PR DESCRIPTION
## Summary
- implement event tracking and cost-cap checks in `TelemetryCollector`
- make TelemetryAPIClient import aiohttp dynamically and handle retries
- improve YAML/JSON parsing and file detection for SpecSchema
- call pytest using the active interpreter in validation
- clean up aiohttp stub

## Testing
- `ruff check src/meta_agent/telemetry.py src/jinja2/__init__.py src/yaml/__init__.py src/meta_agent/models/spec_schema.py src/meta_agent/services/telemetry_client.py src/meta_agent/validation.py`
- `black --check src/meta_agent/telemetry.py src/jinja2/__init__.py src/yaml/__init__.py src/meta_agent/models/spec_schema.py src/meta_agent/services/telemetry_client.py src/meta_agent/validation.py`
- `mypy src/meta_agent` *(fails: Missing stubs and typing errors)*
- `pyright` *(fails: type checking errors)*
- `pytest -q` *(fails: several orchestrator tests fail)*
