### PR TITLE
feat: add telemetry export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,14 @@ branch = true
 markers = [
     "integration: mark a test as an integration test."
 ]
+
+[tool.black]
+line-length = 88
+exclude = '''
+/(
+    src/\.tool_designer
+    |generated_tools
+    |temp_sandbox_test_code
+    |\.venv
+)/
+'''

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,3 +232,49 @@ def test_cli_dashboard_with_data(runner, tmp_path):
     assert "Telemetry Dashboard:" in result.output
     assert "5" in result.output
     assert "$0.10" in result.output
+
+
+def test_cli_export_json(runner, tmp_path):
+    db_path = tmp_path / "tele.db"
+    db = TelemetryDB(db_path)
+    db.record(5, 0.1, 0.2, 1)
+    db.close()
+    out = tmp_path / "export.json"
+    result = runner.invoke(
+        cli,
+        [
+            "export",
+            "--db-path",
+            str(db_path),
+            "--output",
+            str(out),
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0
+    assert out.exists()
+
+
+def test_cli_export_csv(runner, tmp_path):
+    db_path = tmp_path / "tele.db"
+    db = TelemetryDB(db_path)
+    db.record(5, 0.1, 0.2, 1)
+    db.close()
+    out = tmp_path / "export.csv"
+    result = runner.invoke(
+        cli,
+        [
+            "export",
+            "--db-path",
+            str(db_path),
+            "--output",
+            str(out),
+            "--format",
+            "csv",
+            "--metric",
+            "tokens",
+        ],
+    )
+    assert result.exit_code == 0
+    assert out.exists()


### PR DESCRIPTION
## Summary
- extend TelemetryDB with range querying and CSV/JSON export helpers
- add CLI command `export` for telemetry data
- implement tests for new export logic and CLI
- configure Black to ignore generated content

## Testing
- `ruff check src/meta_agent/telemetry_db.py src/meta_agent/cli/main.py tests/test_cli.py tests/unit/test_telemetry_db.py`
- `black --check src/meta_agent/telemetry_db.py src/meta_agent/cli/main.py tests/test_cli.py tests/unit/test_telemetry_db.py`
- `mypy src/meta_agent/telemetry_db.py src/meta_agent/cli/main.py`
- `pyright src/meta_agent/telemetry_db.py`
- `pytest tests/unit/test_telemetry_db.py::test_export_json_and_csv tests/test_cli.py::test_cli_export_json tests/test_cli.py::test_cli_export_csv -v`
