### PR TITLE
test: add telemetry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Generate production-ready agents in minutes, with built-in validation, sandboxin
 *   **Guardrail Designer sub-agent:** Creates validation logic (Pydantic, regex, policy checks) and guardrail tests, embedding safety and compliance early to prevent bad outputs. See [docs/guardrail_designer_guide.md](docs/guardrail_designer_guide.md) for details.
 *   **Automated evaluation harness:** Compiles generated code, executes unit tests, and surfaces results, guaranteeing that the agent "actually runs." See [docs/evaluation_harness_architecture.md](docs/evaluation_harness_architecture.md) for the design.
 *   **Artifact bundle & dependency lock:** Outputs `agent.py`, `tests/`, `requirements.txt`, and an optional diagram. This allows for one-command install and run, ensuring reproducible builds.
-*   **Cost & trace telemetry:** Logs token usage, latency, and spend per generation, helping to manage cloud costs and aid optimization.
+*   **Cost & trace telemetry:** Logs token usage, latency, and spend per generation, helping to manage cloud costs and aid optimization. See [docs/telemetry_overview.md](docs/telemetry_overview.md) for details.
 
 ## User Guide/How to Use
 

--- a/docs/telemetry_overview.md
+++ b/docs/telemetry_overview.md
@@ -1,0 +1,35 @@
+# Telemetry System Overview
+
+Meta Agent collects basic metrics for each generation run using the
+`TelemetryCollector` and persists them in a small SQLite database via
+`TelemetryDB`. Each run stores the number of tokens consumed, the
+estimated cost, total latency and the number of guardrail hits.
+
+## Dashboard
+
+Use the CLI command `meta-agent dashboard` to inspect recorded runs.
+It displays a table summarising timestamp, token usage, cost, latency
+and guardrail violations. When no data is available the command prints
+"No telemetry data found.".
+
+## Exporting Data
+
+Telemetry can be exported in JSON or CSV format using
+`meta-agent export --format <json|csv> --output <file>`.
+Optional `--start` and `--end` parameters filter by timestamp and
+`--metric` can restrict the columns included. Compression is
+supported automatically when the output filename ends with `.gz`.
+
+## API Integration
+
+The optional `TelemetryAPIClient` class sends traces or metrics to
+external services. Endpoints are configured with `EndpointConfig` and
+`attach_runner` can instrument an Agents SDK `Runner` to forward span
+information after each run. Errors while sending are logged and retried
+with backoff.
+
+## Error Handling
+
+The `TelemetryCollector` records cost-cap warnings and guardrail
+violations as events with severity levels. These events can be viewed in
+the exported data for troubleshooting.

--- a/tests/integration/test_telemetry_integration.py
+++ b/tests/integration/test_telemetry_integration.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from meta_agent.cli.main import cli
+from meta_agent.telemetry_db import TelemetryDB
+
+
+@pytest.fixture
+def valid_spec_dict():
+    return {
+        "task_description": "Test agent for CLI",
+        "inputs": {"data": "string"},
+        "outputs": {"status": "string"},
+        "constraints": ["Must run quickly"],
+        "technical_requirements": ["Python 3.10+"],
+        "metadata": {"test_id": "cli-001"},
+    }
+
+
+@pytest.fixture
+def sample_json_file(tmp_path, valid_spec_dict):
+    file_path = tmp_path / "spec.json"
+    with open(file_path, "w") as f:
+        json.dump(valid_spec_dict, f)
+    return file_path
+
+
+def test_generate_records_telemetry(tmp_path, sample_json_file, monkeypatch):
+    runner = CliRunner()
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    result = runner.invoke(
+        cli, ["--no-sensitive-logs", "generate", "--spec-file", str(sample_json_file)]
+    )
+    assert result.exit_code == 0
+    assert "<redacted>" in result.output
+    db_path = Path(tmp_path) / "meta_agent_telemetry.db"
+    db = TelemetryDB(db_path)
+    records = db.fetch_all()
+    db.close()
+    assert len(records) == 1


### PR DESCRIPTION
## Summary
- add integration test covering telemetry DB writes
- link telemetry docs from README
- document telemetry dashboard and export options

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `mypy src/meta_agent` *(fails: 48 errors)*
- `pyright` *(fails: 87 errors)*
- `pytest -q` *(fails: 53 failed, 17 errors)*