### PR TITLE
docs: add telemetry roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Generate production-ready agents in minutes, with built-in validation, sandboxin
 *   **Automated evaluation harness:** Compiles generated code, executes unit tests, and surfaces results, guaranteeing that the agent "actually runs." See [docs/evaluation_harness_architecture.md](docs/evaluation_harness_architecture.md) for the design.
 *   **Artifact bundle & dependency lock:** Outputs `agent.py`, `tests/`, `requirements.txt`, and an optional diagram. This allows for one-command install and run, ensuring reproducible builds.
 *   **Cost & trace telemetry:** Logs token usage, latency, and spend per generation, helping to manage cloud costs and aid optimization. See [docs/telemetry_overview.md](docs/telemetry_overview.md) for details.
+*   See [docs/telemetry_roadmap.md](docs/telemetry_roadmap.md) for the telemetry development roadmap.
 
 ## User Guide/How to Use
 

--- a/docs/telemetry_roadmap.md
+++ b/docs/telemetry_roadmap.md
@@ -1,0 +1,25 @@
+# Telemetry Development Roadmap
+
+Meta Agent's telemetry system begins with a simple CLI interface and will expand to a VS Code experience. This roadmap summarises the planned stages.
+
+## 1. CLI Baseline
+- Record tokens, estimated cost, latency and guardrail hits via `TelemetryCollector`.
+- Persist metrics in a local SQLite database using `TelemetryDB`.
+- Display a one-line summary after each generation and provide `dashboard` and `export` commands.
+- Enforce a default cost cap of $0.50 per run with warnings at 75% and 90%.
+
+## 2. Enhanced CLI Reporting
+- Surface cost cap and guardrail events in the dashboard output.
+- Allow custom cost caps and metric selection via CLI flags.
+- Provide JSON and CSV export suitable for bundling with generated agents.
+
+## 3. VS Code Integration
+- Reuse the telemetry database to power a VS Code panel.
+- Show live token spend and latency charts while an agent runs.
+- Offer quick access to historical runs and export actions from the editor.
+
+## 4. Third-Party Observability
+- Define an adapter layer for forwarding telemetry to external monitoring tools.
+- Support custom endpoints using `TelemetryAPIClient`.
+
+This staged approach ensures useful telemetry is available immediately in the CLI while paving the way for a richer developer experience in VS Code.

--- a/tests/unit/test_telemetry_collector.py
+++ b/tests/unit/test_telemetry_collector.py
@@ -54,3 +54,13 @@ def test_record_event():
     ev = t.events[0]
     assert ev.category == TelemetryCollector.Category.EXECUTION
     assert ev.severity == TelemetryCollector.Severity.ERROR
+
+
+def test_guardrail_event():
+    t = TelemetryCollector()
+    t.increment_guardrail_hits()
+    assert t.guardrail_hits == 1
+    assert len(t.events) == 1
+    ev = t.events[0]
+    assert ev.category == TelemetryCollector.Category.GUARDRAIL
+    assert ev.severity == TelemetryCollector.Severity.WARNING


### PR DESCRIPTION
## Summary
- document telemetry roadmap for CLI and VS Code
- test guardrail event tracking
- link roadmap from README

## Testing
- `ruff check .`
- `black --check tests/unit/test_telemetry_collector.py`
- `pytest tests/unit/test_telemetry_collector.py -v`