### PR TITLE
feat: add customizable telemetry summary

### DIFF
--- a/src/meta_agent/telemetry.py
+++ b/src/meta_agent/telemetry.py
@@ -136,14 +136,31 @@ class TelemetryCollector:
         )
 
     # --- Summary ----------------------------------------------------
-    def summary_line(self) -> str:
-        """Return a one-line summary of collected metrics."""
-        cost = f"${self.cost:.2f}" if self.include_sensitive else "<redacted>"
-        tokens = str(self.token_count) if self.include_sensitive else "<redacted>"
-        return (
-            "Telemetry: "
-            f"cost={cost} "
-            f"tokens={tokens} "
-            f"latency={self.latency:.2f}s "
-            f"guardrails={self.guardrail_hits}"
-        )
+    def summary_line(self, metrics: Optional[List[str]] | None = None) -> str:
+        """Return a one-line summary of selected metrics.
+
+        Parameters
+        ----------
+        metrics:
+            Iterable of metric names to include. Supported values are
+            ``"cost"``, ``"tokens"``, ``"latency"`` and ``"guardrails"``.
+            When ``None`` all metrics are displayed.
+        """
+
+        metrics = metrics or ["cost", "tokens", "latency", "guardrails"]
+        parts: List[str] = []
+        for m in metrics:
+            if m == "cost":
+                cost = f"${self.cost:.2f}" if self.include_sensitive else "<redacted>"
+                parts.append(f"cost={cost}")
+            elif m == "tokens":
+                tokens = (
+                    str(self.token_count) if self.include_sensitive else "<redacted>"
+                )
+                parts.append(f"tokens={tokens}")
+            elif m == "latency":
+                parts.append(f"latency={self.latency:.2f}s")
+            elif m == "guardrails":
+                parts.append(f"guardrails={self.guardrail_hits}")
+        joined = " ".join(parts)
+        return f"Telemetry: {joined}" if joined else "Telemetry:"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,7 +106,19 @@ def test_cli_generate_spec_file_json(runner, sample_json_file):
     # Optionally, check for status: success in the final JSON output
     assert '"status": "simulated_success"' in result.output
     assert "Telemetry:" in result.output
+    assert "cost=" in result.output
+    assert "tokens=" in result.output
+
+
+def test_cli_generate_custom_metrics(runner, sample_json_file):
+    result = runner.invoke(
+        cli,
+        ["generate", "--spec-file", str(sample_json_file), "--metric", "latency"],
+    )
+    assert result.exit_code == 0
     assert "Telemetry:" in result.output
+    assert "latency=" in result.output
+    assert "cost=" not in result.output
 
 
 def test_cli_generate_spec_file_yaml(runner, sample_yaml_file):

--- a/tests/unit/test_telemetry_collector.py
+++ b/tests/unit/test_telemetry_collector.py
@@ -26,6 +26,16 @@ def test_summary_line():
     assert "tokens=0" in line
 
 
+def test_summary_line_custom_metrics():
+    t = TelemetryCollector()
+    t.start_timer()
+    t.stop_timer()
+    line = t.summary_line(["latency"])
+    assert "Telemetry:" in line
+    assert "latency=" in line
+    assert "cost=" not in line
+
+
 def test_cost_cap_threshold_events(caplog):
     t = TelemetryCollector(cost_cap=0.02)
     with caplog.at_level(logging.INFO):


### PR DESCRIPTION
## Summary
- allow selecting metrics for telemetry summary line
- support --metric flag in CLI generate command
- test telemetry summary customization

## Testing
- `ruff check src/meta_agent/telemetry.py src/meta_agent/cli/main.py tests/unit/test_telemetry_collector.py tests/test_cli.py`
- `black --check src/meta_agent/telemetry.py src/meta_agent/cli/main.py tests/unit/test_telemetry_collector.py tests/test_cli.py`
- `pytest tests/unit/test_telemetry_collector.py tests/unit/test_telemetry_db.py tests/test_cli.py::test_cli_generate_spec_file_json tests/test_cli.py::test_cli_generate_custom_metrics tests/integration/test_telemetry_integration.py::test_generate_records_telemetry -q`
- `mypy src/meta_agent/telemetry.py src/meta_agent/cli/main.py tests/unit/test_telemetry_collector.py tests/test_cli.py` *(fails: "Argument 1 has incompatible type")*
- `pyright src/meta_agent/cli/main.py src/meta_agent/telemetry.py tests/unit/test_telemetry_collector.py tests/test_cli.py` *(fails: "Attribute 'model_dump' is unknown")*