### PR TITLE
feat: add template categorization schema

### DIFF
--- a/docs/template_categorization_schema.md
+++ b/docs/template_categorization_schema.md
@@ -1,0 +1,49 @@
+# Template Categorization Schema
+
+This document describes the hierarchical system used to organise agent templates. Each template records a primary category, an optional subcategory and a complexity level. Metadata fields are standardised so that templates can be discovered, filtered and mixed consistently.
+
+## Primary Categories
+
+- **conversation** – Interactive dialogue agents such as chat bots or FAQ assistants.
+- **reasoning** – Step‑by‑step or analytical agents focused on problem solving.
+- **creative** – Templates that produce creative text, images or other media.
+- **data_processing** – Agents that transform or analyse data.
+- **integration** – Templates that orchestrate tools or external APIs.
+
+Additional categories may be introduced in future. Unknown values should be ignored by older tooling.
+
+## Metadata Fields
+
+Each template defines the following fields:
+
+| Field        | Description                                             |
+|--------------|---------------------------------------------------------|
+| `slug`       | Unique identifier used when referencing the template.   |
+| `title`      | Human friendly name.                                    |
+| `description`| Short summary of the template's purpose.                |
+| `category`   | One of the primary categories above.                    |
+| `subcategory`| Optional free‑form subcategory for finer grouping.      |
+| `complexity` | `basic`, `intermediate` or `advanced`.                  |
+| `tags`       | List of additional keywords.                            |
+
+## Classification Examples
+
+```
+- slug: basic-chat
+  title: Basic Chat Bot
+  description: Minimal conversational agent.
+  category: conversation
+  subcategory: qa
+  complexity: basic
+  tags: ["chat", "starter"]
+
+- slug: structured-reasoner
+  title: Structured Reasoner
+  description: Performs multi-step reasoning with tool calls.
+  category: reasoning
+  subcategory: step-by-step
+  complexity: advanced
+  tags: ["chain-of-thought"]
+```
+
+These examples illustrate how templates are labelled using the schema. Tools consuming templates can rely on these fields to search for compatible archetypes and to mix templates with similar characteristics.

--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -13,6 +13,11 @@ from __future__ import annotations
 import builtins
 
 from .bundle import Bundle
+from .template_schema import (
+    TemplateCategory,
+    TemplateComplexity,
+    TemplateMetadata,
+)
 
 # Expose `patch` globally for tests that forget to import it.
 try:
@@ -29,4 +34,9 @@ except Exception:  # pragma: no cover
     # on it and something went wrong here.
     pass
 
-__all__ = ["Bundle"]
+__all__ = [
+    "Bundle",
+    "TemplateCategory",
+    "TemplateComplexity",
+    "TemplateMetadata",
+]

--- a/src/meta_agent/template_schema.py
+++ b/src/meta_agent/template_schema.py
@@ -1,0 +1,49 @@
+"""Data models for template metadata and categorisation."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+try:  # pragma: no cover - pydantic v1 fallback
+    from pydantic import BaseModel, Field
+except ImportError:  # pragma: no cover
+    from pydantic import BaseModel, Field
+
+
+class TemplateCategory(str, Enum):
+    """High level grouping for templates."""
+
+    CONVERSATION = "conversation"
+    REASONING = "reasoning"
+    CREATIVE = "creative"
+    DATA_PROCESSING = "data_processing"
+    INTEGRATION = "integration"
+
+
+class TemplateComplexity(str, Enum):
+    """Rough measure of how involved a template is."""
+
+    BASIC = "basic"
+    INTERMEDIATE = "intermediate"
+    ADVANCED = "advanced"
+
+
+class TemplateMetadata(BaseModel):
+    """Metadata describing a reusable agent template."""
+
+    slug: str = Field(..., description="Unique identifier for the template")
+    title: str = Field(..., description="Human friendly name")
+    description: str = Field(..., description="Short summary of the template")
+    category: TemplateCategory = Field(..., description="Primary template category")
+    subcategory: str | None = Field(
+        default=None, description="Optional secondary grouping"
+    )
+    complexity: TemplateComplexity = Field(
+        default=TemplateComplexity.BASIC,
+        description="Overall complexity level",
+    )
+    tags: List[str] = Field(default_factory=list, description="Additional labels")
+
+    class Config:
+        use_enum_values = False

--- a/tests/test_template_schema.py
+++ b/tests/test_template_schema.py
@@ -1,0 +1,39 @@
+from pydantic import ValidationError
+
+from meta_agent.template_schema import (
+    TemplateCategory,
+    TemplateComplexity,
+    TemplateMetadata,
+)
+
+
+def test_template_metadata_valid() -> None:
+    meta = TemplateMetadata(
+        slug="basic-chat",
+        title="Basic Chat Bot",
+        description="Minimal conversational agent",
+        category=TemplateCategory.CONVERSATION,
+        subcategory="qa",
+        complexity=TemplateComplexity.BASIC,
+        tags=["chat"],
+    )
+    assert meta.slug == "basic-chat"
+    assert meta.category is TemplateCategory.CONVERSATION
+    assert meta.complexity is TemplateComplexity.BASIC
+    assert meta.tags == ["chat"]
+
+
+def test_template_metadata_invalid_category() -> None:
+    try:
+        TemplateMetadata(
+            slug="bad",
+            title="Bad",
+            description="Bad",
+            category="invalid",  # type: ignore[arg-type]
+            subcategory="x",
+            complexity=TemplateComplexity.BASIC,
+        )
+    except ValidationError:
+        pass
+    else:  # pragma: no cover - should not succeed
+        assert False, "ValidationError not raised"


### PR DESCRIPTION
## Summary
- define template schema models
- export template models from package init
- document template categorization scheme
- add tests for template schema

## Testing
- `ruff check src/meta_agent/template_schema.py tests/test_template_schema.py src/meta_agent/__init__.py`
- `black --check src/meta_agent/template_schema.py tests/test_template_schema.py src/meta_agent/__init__.py`
- `mypy src/meta_agent/template_schema.py`
- `pyright src/meta_agent/template_schema.py`
- `pytest tests/test_template_schema.py::test_template_metadata_valid tests/test_template_schema.py::test_template_metadata_invalid_category -q`
- `pytest -q` *(fails: GeneratedTool object has no attribute 'model_dump', ...)*