### PR TITLE
feat: add template versioning system

### DIFF
--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -18,6 +18,7 @@ from .template_schema import (
     TemplateComplexity,
     TemplateMetadata,
 )
+from .template_registry import TemplateRegistry
 
 # Expose `patch` globally for tests that forget to import it.
 try:
@@ -39,4 +40,5 @@ __all__ = [
     "TemplateCategory",
     "TemplateComplexity",
     "TemplateMetadata",
+    "TemplateRegistry",
 ]

--- a/src/meta_agent/template_registry.py
+++ b/src/meta_agent/template_registry.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import logging
+import difflib
+from hashlib import sha256
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from packaging.version import parse as parse_version
+
+from .template_schema import TemplateMetadata
+
+logger = logging.getLogger(__name__)
+
+TEMPLATE_LIBRARY_DIR_NAME = "template_library"
+TEMPLATE_FILE_NAME = "template.yaml"
+METADATA_FILE_NAME = "metadata.json"
+MANIFEST_FILE_NAME = "registry.json"
+
+
+class TemplateRegistry:
+    """Manage versioned agent templates."""
+
+    def __init__(self, base_dir: str | Path = "src/meta_agent") -> None:
+        self.base_dir = Path(base_dir)
+        if not self.base_dir.is_absolute():
+            self.base_dir = Path(__file__).parent
+        self.templates_dir = self.base_dir / TEMPLATE_LIBRARY_DIR_NAME
+        self.templates_dir.mkdir(parents=True, exist_ok=True)
+        self.manifest_path = self.templates_dir / MANIFEST_FILE_NAME
+        if not self.manifest_path.exists():
+            with open(self.manifest_path, "w", encoding="utf-8") as f:
+                json.dump({}, f)
+
+    def _load_manifest(self) -> Dict[str, Any]:
+        try:
+            with open(self.manifest_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (IOError, json.JSONDecodeError):
+            logger.warning("Failed to read template registry manifest. Recreating.")
+            return {}
+
+    def _save_manifest(self, manifest: Dict[str, Any]) -> None:
+        try:
+            with open(self.manifest_path, "w", encoding="utf-8") as f:
+                json.dump(manifest, f, indent=2)
+        except IOError as e:
+            logger.error(f"Failed to write template registry manifest: {e}")
+
+    def register(
+        self,
+        metadata: TemplateMetadata,
+        content: str,
+        version: str = "0.1.0",
+    ) -> Optional[str]:
+        slug = metadata.slug
+        slug_sanitized = slug.replace(" ", "_").lower()
+        version_sanitized = "v" + version.replace(".", "_")
+        version_dir = self.templates_dir / slug_sanitized / version_sanitized
+        version_dir.mkdir(parents=True, exist_ok=True)
+        template_path = version_dir / TEMPLATE_FILE_NAME
+        template_path.write_text(content, encoding="utf-8")
+        checksum = sha256(content.encode("utf-8")).hexdigest()
+        metadata_dict = (
+            metadata.model_dump()
+            if hasattr(metadata, "model_dump")
+            else metadata.dict()
+        )
+        meta_data = {
+            **metadata_dict,
+            "version": version,
+            "checksum": checksum,
+        }
+        with open(version_dir / METADATA_FILE_NAME, "w", encoding="utf-8") as f:
+            json.dump(meta_data, f, indent=2)
+        manifest = self._load_manifest()
+        entry = manifest.setdefault(slug_sanitized, {"versions": {}})
+        entry["versions"][version] = {
+            "path": f"{slug_sanitized}/{version_sanitized}/{TEMPLATE_FILE_NAME}",
+            "checksum": checksum,
+            "created_at": datetime.utcnow().isoformat(),
+        }
+        entry["current_version"] = version
+        self._save_manifest(manifest)
+        return str(template_path)
+
+    def list_templates(self) -> List[Dict[str, Any]]:
+        manifest = self._load_manifest()
+        templates = []
+        for slug, entry in manifest.items():
+            versions = [
+                {"version": v, **data}
+                for v, data in sorted(
+                    entry.get("versions", {}).items(),
+                    key=lambda item: parse_version(item[0]),
+                    reverse=True,
+                )
+            ]
+            templates.append(
+                {
+                    "slug": slug,
+                    "current_version": entry.get("current_version"),
+                    "versions": versions,
+                }
+            )
+        return templates
+
+    def load_template(self, slug: str, version: str = "latest") -> Optional[str]:
+        slug_sanitized = slug.replace(" ", "_").lower()
+        manifest = self._load_manifest()
+        entry = manifest.get(slug_sanitized)
+        if not entry:
+            return None
+        if version == "latest":
+            version = entry.get("current_version")
+            if not version:
+                return None
+        version_data = entry.get("versions", {}).get(version)
+        if not version_data:
+            return None
+        template_path = self.templates_dir / version_data["path"]
+        if not template_path.exists():
+            return None
+        return template_path.read_text(encoding="utf-8")
+
+    def diff(self, slug: str, old_version: str, new_version: str) -> str:
+        old = self.load_template(slug, old_version) or ""
+        new = self.load_template(slug, new_version) or ""
+        return "\n".join(
+            difflib.unified_diff(
+                old.splitlines(),
+                new.splitlines(),
+                fromfile=old_version,
+                tofile=new_version,
+                lineterm="",
+            )
+        )
+
+    def rollback(self, slug: str, version: str) -> bool:
+        slug_sanitized = slug.replace(" ", "_").lower()
+        manifest = self._load_manifest()
+        entry = manifest.get(slug_sanitized)
+        if not entry or version not in entry.get("versions", {}):
+            return False
+        entry["current_version"] = version
+        self._save_manifest(manifest)
+        return True

--- a/tasks/task_009.txt
+++ b/tasks/task_009.txt
@@ -24,7 +24,7 @@ Test template retrieval with various specifications. Verify template mixing prod
 ### Details:
 Define primary template categories (e.g., conversation, reasoning, creative), subcategories, and metadata fields needed for each template. Create a document outlining the schema with examples of how different templates would be classified.
 
-## 2. Implement template versioning system [pending]
+## 2. Implement template versioning system [done]
 ### Dependencies: 9.1
 ### Description: Develop a versioning mechanism to track template changes and maintain backward compatibility
 ### Details:

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -1,0 +1,48 @@
+from meta_agent.template_registry import TemplateRegistry
+from meta_agent.template_schema import (
+    TemplateMetadata,
+    TemplateCategory,
+    TemplateComplexity,
+)
+
+
+def _meta() -> TemplateMetadata:
+    return TemplateMetadata(
+        slug="greet",
+        title="Greeting",
+        description="Say hi",
+        category=TemplateCategory.CONVERSATION,
+        complexity=TemplateComplexity.BASIC,
+        tags=["demo"],
+    )
+
+
+def test_register_and_load(tmp_path):
+    reg = TemplateRegistry(base_dir=tmp_path)
+    meta = _meta()
+    reg.register(meta, "hello {{name}}", version="0.1.0")
+
+    templates = reg.list_templates()
+    assert len(templates) == 1
+    info = templates[0]
+    assert info["slug"] == "greet"
+    assert info["current_version"] == "0.1.0"
+    assert info["versions"][0]["version"] == "0.1.0"
+
+    content = reg.load_template("greet")
+    assert content == "hello {{name}}"
+
+
+def test_versioning_diff_and_rollback(tmp_path):
+    reg = TemplateRegistry(base_dir=tmp_path)
+    meta = _meta()
+    reg.register(meta, "hello {{name}}", version="0.1.0")
+    reg.register(meta, "hi {{name}}", version="0.2.0")
+
+    diff = reg.diff("greet", "0.1.0", "0.2.0")
+    assert "-hello {{name}}" in diff
+    assert "+hi {{name}}" in diff
+
+    reg.rollback("greet", "0.1.0")
+    assert reg.list_templates()[0]["current_version"] == "0.1.0"
+    assert reg.load_template("greet") == "hello {{name}}"


### PR DESCRIPTION
## Summary
- implement `TemplateRegistry` for storing versioned templates
- expose `TemplateRegistry` in package init
- mark task 9.2 as done
- add tests for template registry

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `mypy src/meta_agent` *(fails: found 47 errors)*
- `pyright` *(fails with 88 errors)*
- `pytest -v tests` *(fails: 47 failed, 272 passed, 17 errors)*
