### PR TITLE
feat: add template search engine

### DIFF
--- a/src/meta_agent/template_search.py
+++ b/src/meta_agent/template_search.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .template_registry import TemplateRegistry, METADATA_FILE_NAME
+
+
+@dataclass
+class TemplateMatch:
+    """Single search result with relevance score."""
+
+    slug: str
+    version: str
+    score: float
+    preview: str
+    metadata: Dict[str, Any]
+
+
+class TemplateSearchEngine:
+    """Very small full-text search over registered templates."""
+
+    def __init__(self, registry: Optional[TemplateRegistry] = None) -> None:
+        self.registry = registry or TemplateRegistry()
+        self._index: List[Dict[str, Any]] = []
+
+    def build_index(self) -> None:
+        """Build an in-memory index of template metadata and content."""
+        self._index.clear()
+        for entry in self.registry.list_templates():
+            slug = entry["slug"]
+            version = entry.get("current_version")
+            if not version:
+                continue
+            content = self.registry.load_template(slug, version) or ""
+            metadata_path = (
+                self.registry.templates_dir
+                / slug.replace(" ", "_").lower()
+                / f"v{version.replace('.', '_')}"
+                / METADATA_FILE_NAME
+            )
+            try:
+                with open(metadata_path, "r", encoding="utf-8") as f:
+                    metadata = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                metadata = {}
+            self._index.append(
+                {
+                    "slug": slug,
+                    "version": version,
+                    "metadata": metadata,
+                    "content": content,
+                }
+            )
+
+    def search(
+        self,
+        query: str,
+        *,
+        category: str | None = None,
+        tags: Optional[List[str]] = None,
+        limit: int = 5,
+    ) -> List[TemplateMatch]:
+        """Return templates matching the query and optional filters."""
+        if not self._index:
+            self.build_index()
+        tokens = [t.lower() for t in query.split() if t]
+        results: List[TemplateMatch] = []
+        for item in self._index:
+            meta = item.get("metadata", {})
+            if category and meta.get("category") != category:
+                continue
+            if tags and not all(t in meta.get("tags", []) for t in tags):
+                continue
+            haystack = " ".join(
+                [
+                    item.get("content", ""),
+                    meta.get("title", ""),
+                    meta.get("description", ""),
+                    meta.get("slug", ""),
+                    " ".join(meta.get("tags", [])),
+                ]
+            ).lower()
+            score = sum(1 for tok in tokens if tok in haystack)
+            if score:
+                preview = item.get("content", "")[:100].strip()
+                results.append(
+                    TemplateMatch(
+                        slug=item["slug"],
+                        version=item["version"],
+                        score=float(score),
+                        preview=preview,
+                        metadata=meta,
+                    )
+                )
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[:limit]

--- a/tests/test_template_search.py
+++ b/tests/test_template_search.py
@@ -1,0 +1,46 @@
+from meta_agent.template_registry import TemplateRegistry
+from meta_agent.template_schema import (
+    TemplateMetadata,
+    TemplateCategory,
+    TemplateComplexity,
+)
+from meta_agent.template_search import TemplateSearchEngine
+
+
+def _meta(slug: str, category: TemplateCategory) -> TemplateMetadata:
+    return TemplateMetadata(
+        slug=slug,
+        title=slug.title(),
+        description=f"Template {slug}",
+        category=category,
+        complexity=TemplateComplexity.BASIC,
+        tags=[slug],
+    )
+
+
+def test_search_basic(tmp_path):
+    reg = TemplateRegistry(base_dir=tmp_path)
+    reg.register(_meta("greet", TemplateCategory.CONVERSATION), "hello world")
+    reg.register(_meta("calc", TemplateCategory.REASONING), "1 + 1")
+
+    engine = TemplateSearchEngine(reg)
+    results = engine.search("hello")
+    assert results
+    assert results[0].slug == "greet"
+    assert "hello" in results[0].preview
+
+
+def test_search_filters(tmp_path):
+    reg = TemplateRegistry(base_dir=tmp_path)
+    reg.register(_meta("foo", TemplateCategory.CONVERSATION), "foo content")
+    reg.register(_meta("bar", TemplateCategory.REASONING), "bar content")
+
+    engine = TemplateSearchEngine(reg)
+    res_cat = engine.search("content", category=TemplateCategory.CONVERSATION.value)
+    assert len(res_cat) == 1 and res_cat[0].slug == "foo"
+
+    res_tag = engine.search("content", tags=["bar"])
+    assert len(res_tag) == 1 and res_tag[0].slug == "bar"
+
+    res_none = engine.search("content", tags=["missing"])
+    assert res_none == []


### PR DESCRIPTION
## Summary
- add a simple template search engine module
- include unit tests for template search

## Testing
- `ruff check src/meta_agent/template_search.py tests/test_template_search.py`
- `black --check src/meta_agent/template_search.py tests/test_template_search.py`
- `mypy src/meta_agent/template_search.py tests/test_template_search.py`
- `pyright src/meta_agent/template_search.py tests/test_template_search.py`
- `pytest tests/test_template_search.py -q`
- `pytest -q` *(fails: 47 failed, 274 passed, 2 skipped, 17 errors)*