### PR TITLE
feat: add template creator

### DIFF
--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -19,6 +19,7 @@ from .template_schema import (
     TemplateMetadata,
 )
 from .template_registry import TemplateRegistry
+from .template_creator import TemplateCreator, validate_template
 
 # Expose `patch` globally for tests that forget to import it.
 try:
@@ -41,4 +42,6 @@ __all__ = [
     "TemplateComplexity",
     "TemplateMetadata",
     "TemplateRegistry",
+    "TemplateCreator",
+    "validate_template",
 ]

--- a/src/meta_agent/template_creator.py
+++ b/src/meta_agent/template_creator.py
@@ -1,0 +1,43 @@
+"""Interface for creating user defined templates."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from jinja2 import Environment, TemplateSyntaxError
+
+from .template_registry import TemplateRegistry
+from .template_schema import TemplateMetadata
+
+
+def validate_template(content: str) -> Tuple[bool, str]:
+    """Check that the template is valid Jinja2."""
+    try:
+        Environment().parse(content)
+    except TemplateSyntaxError as e:  # pragma: no cover - jinja2 handled
+        return False, str(e)
+    return True, ""
+
+
+class TemplateCreator:
+    """Create and register templates."""
+
+    def __init__(self, registry: Optional[TemplateRegistry] = None) -> None:
+        self.registry = registry or TemplateRegistry()
+
+    def create(
+        self,
+        metadata: TemplateMetadata,
+        content: str,
+        *,
+        version: str = "0.1.0",
+        validate: bool = True,
+    ) -> Optional[str]:
+        """Register a template after optional validation."""
+        if validate:
+            ok, err = validate_template(content)
+            if not ok:
+                raise ValueError(f"Template validation failed: {err}")
+        if not content.strip():
+            raise ValueError("Template content cannot be empty")
+        return self.registry.register(metadata, content, version)

--- a/tests/test_template_creator.py
+++ b/tests/test_template_creator.py
@@ -1,0 +1,36 @@
+from meta_agent.template_creator import TemplateCreator, validate_template
+from meta_agent.template_schema import (
+    TemplateMetadata,
+    TemplateCategory,
+    TemplateComplexity,
+)
+from meta_agent.template_registry import TemplateRegistry
+
+
+def _meta() -> TemplateMetadata:
+    return TemplateMetadata(
+        slug="demo",
+        title="Demo Template",
+        description="Simple demo",
+        category=TemplateCategory.CONVERSATION,
+        complexity=TemplateComplexity.BASIC,
+        tags=["demo"],
+    )
+
+
+def test_validate_template_success() -> None:
+    ok, err = validate_template("hello {{ name }}")
+    assert ok and err == ""
+
+
+def test_validate_template_failure() -> None:
+    ok, err = validate_template("{% for x in %}")
+    assert not ok and err
+
+
+def test_creator_register(tmp_path) -> None:
+    reg = TemplateRegistry(base_dir=tmp_path)
+    creator = TemplateCreator(reg)
+    path = creator.create(_meta(), "hi {{name}}", version="0.1.0")
+    assert path
+    assert reg.load_template("demo") == "hi {{name}}"


### PR DESCRIPTION
## Summary
- introduce `TemplateCreator` to register custom templates
- export helper in `__init__`
- test creating templates and template validation

## Testing
- `ruff check src/meta_agent/template_creator.py tests/test_template_creator.py src/meta_agent/__init__.py`
- `black --check src/meta_agent/template_creator.py src/meta_agent/__init__.py tests/test_template_creator.py`
- `mypy src/meta_agent` *(fails: Incompatible types in assignment)*
- `pyright` *(fails: 91 errors)*
- `pytest -q` *(fails: 53 errors during collection)*