### PR TITLE
feat: add template mixer

### DIFF
--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -20,6 +20,7 @@ from .template_schema import (
 )
 from .template_registry import TemplateRegistry
 from .template_creator import TemplateCreator, validate_template
+from .template_mixer import TemplateMixer
 
 # Expose `patch` globally for tests that forget to import it.
 try:
@@ -44,4 +45,5 @@ __all__ = [
     "TemplateRegistry",
     "TemplateCreator",
     "validate_template",
+    "TemplateMixer",
 ]

--- a/src/meta_agent/template_mixer.py
+++ b/src/meta_agent/template_mixer.py
@@ -1,0 +1,77 @@
+"""Template mixing and inheritance utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from jinja2 import BaseLoader, Environment, TemplateNotFound
+
+from .template_registry import TemplateRegistry
+
+
+def _split_name(name: str) -> Tuple[str, str]:
+    """Split ``slug@version`` into components."""
+    if "@" in name:
+        slug, version = name.split("@", 1)
+    else:
+        slug, version = name, "latest"
+    return slug, version
+
+
+class _RegistryLoader(BaseLoader):
+    """Jinja loader that pulls templates from a :class:`TemplateRegistry`."""
+
+    def __init__(self, registry: TemplateRegistry) -> None:
+        self.registry = registry
+
+    def get_source(
+        self, environment: Environment, template: str
+    ) -> Tuple[str, str, Any]:
+        slug, version = _split_name(template)
+        source = self.registry.load_template(slug, version)
+        if source is None:
+            raise TemplateNotFound(template)
+        return source, template, lambda: True
+
+
+class TemplateMixer:
+    """Render templates that extend or include other templates."""
+
+    def __init__(self, registry: Optional[TemplateRegistry] = None) -> None:
+        self.registry = registry or TemplateRegistry()
+        self.env = Environment(loader=_RegistryLoader(self.registry))
+
+    def render(
+        self,
+        slug: str,
+        *,
+        version: str = "latest",
+        context: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Render a template and all of its dependencies."""
+        name = slug if version == "latest" else f"{slug}@{version}"
+        template = self.env.get_template(name)
+        return template.render(context or {})
+
+    def dependency_graph(
+        self, slug: str, *, version: str = "latest"
+    ) -> Dict[str, List[str]]:
+        """Return a mapping of template to templates it references via ``extends`` or ``include``."""
+
+        visited: Dict[str, List[str]] = {}
+        pattern = re.compile(r"{%\s*(?:extends|include)\s+'([^']+)'")
+
+        def _walk(name: str) -> None:
+            if name in visited:
+                return
+            s, v = _split_name(name)
+            source = self.registry.load_template(s, v) or ""
+            deps = pattern.findall(source)
+            visited[name] = deps
+            for dep in deps:
+                _walk(dep)
+
+        root = slug if version == "latest" else f"{slug}@{version}"
+        _walk(root)
+        return visited

--- a/tests/test_template_mixer.py
+++ b/tests/test_template_mixer.py
@@ -1,0 +1,46 @@
+from meta_agent.template_mixer import TemplateMixer
+from meta_agent.template_creator import TemplateCreator
+from meta_agent.template_schema import (
+    TemplateMetadata,
+    TemplateCategory,
+    TemplateComplexity,
+)
+from meta_agent.template_registry import TemplateRegistry
+
+
+def _meta(slug: str) -> TemplateMetadata:
+    return TemplateMetadata(
+        slug=slug,
+        title=slug,
+        description="demo",
+        category=TemplateCategory.CONVERSATION,
+        complexity=TemplateComplexity.BASIC,
+    )
+
+
+def test_render_inheritance(tmp_path) -> None:
+    reg = TemplateRegistry(base_dir=tmp_path)
+    creator = TemplateCreator(reg)
+    creator.create(_meta("base"), "{% block greet %}Hello{% endblock %}")
+    creator.create(
+        _meta("child"),
+        "{% extends 'base' %}{% block greet %}{{ super() }} {{ name }}{% endblock %}",
+    )
+
+    mixer = TemplateMixer(reg)
+    result = mixer.render("child", context={"name": "Bob"})
+    assert result.strip() == "Hello Bob"
+
+
+def test_dependency_graph(tmp_path) -> None:
+    reg = TemplateRegistry(base_dir=tmp_path)
+    creator = TemplateCreator(reg)
+    creator.create(_meta("a"), "A")
+    creator.create(_meta("b"), "{% extends 'a' %}B")
+    creator.create(_meta("c"), "{% include 'b' %}C")
+
+    mixer = TemplateMixer(reg)
+    graph = mixer.dependency_graph("c")
+    assert graph["c"] == ["b"]
+    assert graph["b"] == ["a"]
+    assert graph["a"] == []


### PR DESCRIPTION
## Summary
- implement `TemplateMixer` for template inheritance
- expose mixer from package
- test rendering and dependency graph features

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `mypy src/meta_agent` *(fails: found 52 errors)*
- `pyright` *(fails: 93 errors)*
- `pytest -q` *(fails: 53 errors during collection)*