### PR TITLE
feat: add template index

### DIFF
--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -8,6 +8,7 @@ identifier ``patch`` without importing it; adding the alias
 here prevents a ``NameError`` during test collection/execution
 while remaining completely harmless in regular usage.
 """
+# ruff: noqa: E402
 from __future__ import annotations
 
 import sys
@@ -33,6 +34,7 @@ from .template_creator import TemplateCreator, validate_template
 from .template_mixer import TemplateMixer
 from .template_validator import TemplateValidator, TemplateTestCase
 from .template_sharing import TemplateSharingManager
+from .template_index import TemplateIndex
 
 # Expose `patch` globally for tests that forget to import it.
 try:
@@ -76,4 +78,5 @@ __all__ = [
     "TemplateValidator",
     "TemplateTestCase",
     "TemplateSharingManager",
+    "TemplateIndex",
 ]

--- a/src/meta_agent/template_index.py
+++ b/src/meta_agent/template_index.py
@@ -1,0 +1,133 @@
+"""Persistent search index for templates."""
+
+from __future__ import annotations
+
+import json
+from hashlib import sha256
+from typing import Any, Dict, List, Optional
+
+from .template_registry import TemplateRegistry, METADATA_FILE_NAME
+
+
+class TemplateIndex:
+    """Manage a simple on-disk index of templates for quick search."""
+
+    INDEX_FILE_NAME = "index.json"
+
+    def __init__(self, registry: Optional[TemplateRegistry] = None) -> None:
+        self.registry = registry or TemplateRegistry()
+        self.index_path = self.registry.templates_dir / self.INDEX_FILE_NAME
+        self._index: List[Dict[str, Any]] = []
+
+    # ------------------------------------------------------------------
+    def load(self) -> None:
+        if self.index_path.exists():
+            try:
+                with open(self.index_path, "r", encoding="utf-8") as f:
+                    self._index = json.load(f)
+            except (OSError, json.JSONDecodeError):  # pragma: no cover - corrupt file
+                self._index = []
+        else:
+            self._index = []
+
+    def save(self) -> None:
+        with open(self.index_path, "w", encoding="utf-8") as f:
+            json.dump(self._index, f, indent=2)
+
+    # ------------------------------------------------------------------
+    def rebuild(self) -> None:
+        """Rebuild the index from all registered templates."""
+        self._index = []
+        for entry in self.registry.list_templates():
+            slug = entry["slug"]
+            for version_info in entry.get("versions", []):
+                version = version_info["version"]
+                path = self.registry.templates_dir / version_info["path"]
+                metadata_path = path.parent / METADATA_FILE_NAME
+                try:
+                    content = path.read_text(encoding="utf-8")
+                except OSError:  # pragma: no cover - file missing
+                    continue
+                checksum = sha256(content.encode("utf-8")).hexdigest()
+                try:
+                    with open(metadata_path, "r", encoding="utf-8") as f:
+                        metadata = json.load(f)
+                except (OSError, json.JSONDecodeError):
+                    metadata = {}
+                self._index.append(
+                    {
+                        "slug": slug,
+                        "version": version,
+                        "path": str(path.relative_to(self.registry.templates_dir)),
+                        "checksum": checksum,
+                        "metadata": metadata,
+                        "content": content,
+                    }
+                )
+        self.save()
+
+    # ------------------------------------------------------------------
+    def needs_rebuild(self) -> bool:
+        """Return True if stored checksums differ from source files."""
+        if not self.index_path.exists():
+            return True
+        if not self._index:
+            self.load()
+        for item in self._index:
+            template_path = self.registry.templates_dir / item["path"]
+            try:
+                content = template_path.read_text(encoding="utf-8")
+            except OSError:  # file removed
+                return True
+            checksum = sha256(content.encode("utf-8")).hexdigest()
+            if checksum != item.get("checksum"):
+                return True
+        # check for new templates not in index
+        seen = {(i["slug"], i["version"]) for i in self._index}
+        for entry in self.registry.list_templates():
+            slug = entry["slug"]
+            for version_info in entry.get("versions", []):
+                if (slug, version_info["version"]) not in seen:
+                    return True
+        return False
+
+    def ensure_up_to_date(self) -> None:
+        if self.needs_rebuild():
+            self.rebuild()
+        else:
+            self.load()
+
+    # ------------------------------------------------------------------
+    def search(
+        self,
+        query: str,
+        *,
+        category: str | None = None,
+        tags: Optional[List[str]] = None,
+        limit: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Search the index using a simple token overlap ranking."""
+        if not self._index:
+            self.ensure_up_to_date()
+        tokens = [t.lower() for t in query.split() if t]
+        results = []
+        for item in self._index:
+            meta = item.get("metadata", {})
+            if category and meta.get("category") != category:
+                continue
+            if tags and not all(t in meta.get("tags", []) for t in tags):
+                continue
+            haystack = " ".join(
+                [
+                    item.get("content", ""),
+                    meta.get("title", ""),
+                    meta.get("description", ""),
+                    meta.get("slug", ""),
+                    " ".join(meta.get("tags", [])),
+                ]
+            ).lower()
+            score = sum(1 for tok in tokens if tok in haystack)
+            if score:
+                results.append({**item, "score": float(score)})
+        results.sort(key=lambda r: r["score"], reverse=True)
+        return results[:limit]

--- a/src/meta_agent/validation.py
+++ b/src/meta_agent/validation.py
@@ -80,7 +80,7 @@ def validate_generated_tool(
         has_pytest_cov = False
         if not is_edge_case:
             try:
-                import pytest_cov  # type: ignore
+                import pytest_cov  # noqa: F401  # type: ignore
 
                 has_pytest_cov = True
             except Exception:  # pragma: no cover - plugin not installed

--- a/tasks/task_009.txt
+++ b/tasks/task_009.txt
@@ -63,7 +63,7 @@ For the template validation and testing framework, create a 'golden-spec fuzz se
 ### Details:
 Implement template export/import, sharing permissions, collaborative editing, version merging, and a rating/review system. Create a community showcase for popular templates with usage statistics.
 
-## 8. Implement storage-vs-index architecture [pending]
+## 8. Implement storage-vs-index architecture [done]
 ### Dependencies: 9.1
 ### Description: Create a system that separates version-controlled template storage from retrieval index
 ### Details:

--- a/tests/test_template_index.py
+++ b/tests/test_template_index.py
@@ -1,0 +1,46 @@
+from meta_agent.template_registry import TemplateRegistry
+from meta_agent.template_schema import (
+    TemplateCategory,
+    TemplateComplexity,
+    TemplateMetadata,
+)
+from meta_agent.template_index import TemplateIndex
+
+
+def _meta(slug: str) -> TemplateMetadata:
+    return TemplateMetadata(
+        slug=slug,
+        title=slug,
+        description="demo",
+        category=TemplateCategory.CONVERSATION,
+        complexity=TemplateComplexity.BASIC,
+        tags=[slug],
+    )
+
+
+def test_build_and_search(tmp_path) -> None:
+    reg = TemplateRegistry(base_dir=tmp_path)
+    reg.register(_meta("foo"), "hello foo")
+    reg.register(_meta("bar"), "hello bar")
+
+    index = TemplateIndex(reg)
+    index.rebuild()
+
+    results = index.search("hello foo")
+    assert results and results[0]["slug"] == "foo"
+
+
+def test_auto_rebuild_on_drift(tmp_path) -> None:
+    reg = TemplateRegistry(base_dir=tmp_path)
+    reg.register(_meta("foo"), "hello foo")
+
+    index = TemplateIndex(reg)
+    index.rebuild()
+
+    # modify template to trigger checksum mismatch
+    tpl_path = reg.templates_dir / "foo" / "v0_1_0" / "template.yaml"
+    tpl_path.write_text("hi foo", encoding="utf-8")
+
+    index.ensure_up_to_date()
+    results = index.search("hi foo")
+    assert results and results[0]["slug"] == "foo"


### PR DESCRIPTION
## Summary
- implement persistent template index with on-disk JSON file
- expose TemplateIndex from package
- add tests for template index
- mark storage-vs-index subtask done

## Testing
- `ruff check .`
- `black --check .` *(fails: many files would be reformatted)*
- `pytest -q` *(fails: 17 errors - fixture 'mocker' not found)*
- `mypy .` *(fails: duplicate module error)*
- `pyright` *(fails with type errors)*

------
https://chatgpt.com/codex/tasks/task_e_683a0c77ad74832f8a8e4bf855f30c20