### PR TITLE
fix: robust spec parsing

### DIFF
--- a/src/meta_agent/parsers/tool_spec_parser.py
+++ b/src/meta_agent/parsers/tool_spec_parser.py
@@ -1,5 +1,6 @@
 import json
 import yaml
+import textwrap
 
 try:
     from pydantic import BaseModel, Field, ValidationError, ConfigDict, field_validator
@@ -104,13 +105,14 @@ class ToolSpecificationParser:
             if isinstance(self.raw_specification, dict):
                 data = self.raw_specification
             elif isinstance(self.raw_specification, str):
+                text_spec = textwrap.dedent(self.raw_specification)
                 # Try parsing as JSON first
                 try:
-                    data = json.loads(self.raw_specification)
+                    data = json.loads(text_spec)
                 except json.JSONDecodeError:
                     # If JSON fails, try parsing as YAML
                     try:
-                        data = yaml.safe_load(self.raw_specification)
+                        data = yaml.safe_load(text_spec)
                         if data is None or not isinstance(data, dict):
                             self.errors.append(
                                 "YAML specification did not parse into a dictionary."


### PR DESCRIPTION
## Summary
- normalize text specifications before parsing

## Testing
- `pytest tests/agents/test_tool_designer_agent.py::test_design_tool_success_yaml tests/agents/test_tool_designer_agent.py::test_design_tool_invalid_spec tests/agents/test_tool_designer_agent.py::test_design_tool_generation_error tests/parsers/test_tool_spec_parser.py::test_parse_valid_yaml tests/parsers/test_tool_spec_parser.py::test_parse_yaml_not_dict tests/test_cli.py::test_cli_generate_spec_text_yaml -q`

------
https://chatgpt.com/codex/tasks/task_e_683c3af84d50832fa0d170e811132f38