### PR TITLE
feat: add rich template metadata

### DIFF
--- a/docs/template_categorization_schema.md
+++ b/docs/template_categorization_schema.md
@@ -18,13 +18,24 @@ Each template defines the following fields:
 
 | Field        | Description                                             |
 |--------------|---------------------------------------------------------|
-| `slug`       | Unique identifier used when referencing the template.   |
-| `title`      | Human friendly name.                                    |
-| `description`| Short summary of the template's purpose.                |
-| `category`   | One of the primary categories above.                    |
-| `subcategory`| Optional free‑form subcategory for finer grouping.      |
-| `complexity` | `basic`, `intermediate` or `advanced`.                  |
-| `tags`       | List of additional keywords.                            |
+| `slug`            | Unique identifier used when referencing the template.   |
+| `title`           | Human friendly name.                                    |
+| `description`     | Short summary of the template's purpose.                |
+| `intended_use`    | Primary scenario the template targets.                  |
+| `io_contract`     | Mapping of expected input and output.                   |
+| `tools`           | Tools referenced by the template.                       |
+| `guardrails`      | Guardrails applied when running the template.           |
+| `model_pref`      | Preferred model/provider for generation.                |
+| `category`        | One of the primary categories above.                    |
+| `subcategory`     | Optional free‑form subcategory for finer grouping.      |
+| `complexity`      | `basic`, `intermediate` or `advanced`.                  |
+| `created_by`      | Author or source of the template.                       |
+| `semver`          | Semantic version of the template.                       |
+| `last_test_passed`| ISO timestamp when tests last passed.                   |
+| `tags`            | List of additional keywords.                            |
+| `eval_score`      | (optional) Evaluation score from tests.                 |
+| `cost_estimate`   | (optional) Estimated cost per run in dollars.           |
+| `tokens_per_run`  | (optional) Approximate token usage per run.             |
 
 ## Classification Examples
 
@@ -32,6 +43,13 @@ Each template defines the following fields:
 - slug: basic-chat
   title: Basic Chat Bot
   description: Minimal conversational agent.
+  intended_use: demo
+  io_contract:
+    input: text
+    output: text
+  tools: []
+  guardrails: []
+  model_pref: gpt3
   category: conversation
   subcategory: qa
   complexity: basic
@@ -40,6 +58,13 @@ Each template defines the following fields:
 - slug: structured-reasoner
   title: Structured Reasoner
   description: Performs multi-step reasoning with tool calls.
+  intended_use: demo
+  io_contract:
+    input: text
+    output: text
+  tools: []
+  guardrails: []
+  model_pref: gpt3
   category: reasoning
   subcategory: step-by-step
   complexity: advanced

--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -20,6 +20,7 @@ from .template_schema import (
     TemplateCategory,
     TemplateComplexity,
     TemplateMetadata,
+    IOContract,
 )
 from .template_registry import TemplateRegistry
 from .template_creator import TemplateCreator, validate_template
@@ -67,6 +68,7 @@ __all__ = [
     "TemplateCategory",
     "TemplateComplexity",
     "TemplateMetadata",
+    "IOContract",
     "TemplateRegistry",
     "TemplateCreator",
     "validate_template",

--- a/src/meta_agent/template_mixer.py
+++ b/src/meta_agent/template_mixer.py
@@ -25,14 +25,12 @@ class _RegistryLoader(BaseLoader):
     def __init__(self, registry: TemplateRegistry) -> None:
         self.registry = registry
 
-    def get_source(
-        self, environment: Environment, template: str
-    ) -> Tuple[str, str, Any]:
+    def get_source(self, environment: Environment, template: str) -> str:
         slug, version = _split_name(template)
         source = self.registry.load_template(slug, version)
         if source is None:
             raise TemplateNotFound(template)
-        return source, template, lambda: True
+        return source
 
 
 class TemplateMixer:
@@ -50,9 +48,44 @@ class TemplateMixer:
         context: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Render a template and all of its dependencies."""
-        name = slug if version == "latest" else f"{slug}@{version}"
-        template = self.env.get_template(name)
-        return template.render(context or {})
+
+        def _render_source(source: str) -> str:
+            # handle extends directive
+            match = re.search(r"{%\s*extends\s+'([^']+)'\s*%}", source)
+            if match:
+                parent_slug = match.group(1)
+                parent = self.registry.load_template(parent_slug, version) or ""
+                source = source.replace(match.group(0), "")
+                base = _render_source(parent)
+                block_re = re.compile(
+                    r"{%\s*block\s+(\w+)\s*%}(.*?){%\s*endblock\s*%}", re.S
+                )
+                parent_blocks = {n: c for n, c in block_re.findall(base)}
+                child_blocks = {n: c for n, c in block_re.findall(source)}
+                for name, content in parent_blocks.items():
+                    if name in child_blocks:
+                        child = child_blocks[name].replace("{{ super() }}", content)
+                        pattern = (
+                            r"{%\s*block\s+"
+                            + re.escape(name)
+                            + r"\s*%}.*?{%\s*endblock\s*%}"
+                        )
+                        base = re.sub(pattern, child, base, flags=re.S)
+                source = base
+            # handle include directive
+            include_re = re.compile(r"{%\s*include\s+'([^']+)'\s*%}")
+
+            def _replace_include(m: re.Match[str]) -> str:
+                inc = self.registry.load_template(m.group(1), version) or ""
+                return _render_source(inc)
+
+            source = include_re.sub(_replace_include, source)
+            return source
+
+        raw = self.registry.load_template(slug, version) or ""
+        processed = _render_source(raw)
+        template = self.env.from_string(processed)
+        return template.render(**(context or {}))
 
     def dependency_graph(
         self, slug: str, *, version: str = "latest"

--- a/src/meta_agent/template_schema.py
+++ b/src/meta_agent/template_schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 try:  # pragma: no cover - pydantic v1 fallback
     from pydantic import BaseModel, Field
@@ -29,21 +29,50 @@ class TemplateComplexity(str, Enum):
     ADVANCED = "advanced"
 
 
+class IOContract(BaseModel):
+    """Input/output contract for a template."""
+
+    input: str = Field(..., description="Expected input description")
+    output: str = Field(..., description="Expected output description")
+
+
 class TemplateMetadata(BaseModel):
     """Metadata describing a reusable agent template."""
 
     slug: str = Field(..., description="Unique identifier for the template")
     title: str = Field(..., description="Human friendly name")
     description: str = Field(..., description="Short summary of the template")
+    intended_use: str = Field(..., description="Primary scenario the template targets")
+    io_contract: IOContract = Field(..., description="Expected inputs and outputs")
+    tools: List[str] = Field(default_factory=list, description="Tools referenced")
+    guardrails: List[str] = Field(
+        default_factory=list, description="Guardrails applied"
+    )
+    model_pref: str = Field(..., description="Preferred model or provider")
     category: TemplateCategory = Field(..., description="Primary template category")
-    subcategory: str | None = Field(
+    subcategory: Optional[str] = Field(
         default=None, description="Optional secondary grouping"
     )
     complexity: TemplateComplexity = Field(
         default=TemplateComplexity.BASIC,
         description="Overall complexity level",
     )
+    created_by: str = Field(..., description="Author or source of the template")
+    semver: str = Field(..., description="Semantic version of the template")
+    last_test_passed: Optional[str] = Field(
+        default=None,
+        description="ISO timestamp when tests last passed",
+    )
     tags: List[str] = Field(default_factory=list, description="Additional labels")
+    eval_score: Optional[float] = Field(
+        default=None, description="Evaluation score from automated tests"
+    )
+    cost_estimate: Optional[float] = Field(
+        default=None, description="Estimated cost per run in dollars"
+    )
+    tokens_per_run: Optional[int] = Field(
+        default=None, description="Approximate token usage per run"
+    )
 
     class Config:
         use_enum_values = False

--- a/src/meta_agent/template_sharing.py
+++ b/src/meta_agent/template_sharing.py
@@ -65,10 +65,21 @@ class TemplateSharingManager:
             slug=meta["slug"],
             title=meta.get("title", meta["slug"]),
             description=meta.get("description", ""),
+            intended_use=meta.get("intended_use", ""),
+            io_contract=meta.get("io_contract", {"input": "", "output": ""}),
+            tools=meta.get("tools", []),
+            guardrails=meta.get("guardrails", []),
+            model_pref=meta.get("model_pref", ""),
             category=meta.get("category"),
             subcategory=meta.get("subcategory"),
             complexity=meta.get("complexity"),
+            created_by=meta.get("created_by", "unknown"),
+            semver=meta.get("semver", "0.0.0"),
+            last_test_passed=meta.get("last_test_passed"),
             tags=meta.get("tags", []),
+            eval_score=meta.get("eval_score"),
+            cost_estimate=meta.get("cost_estimate"),
+            tokens_per_run=meta.get("tokens_per_run"),
         )
         version = meta.get("version", "0.1.0")
         creator = TemplateCreator(self.registry)

--- a/tests/test_template_creator.py
+++ b/tests/test_template_creator.py
@@ -12,8 +12,16 @@ def _meta() -> TemplateMetadata:
         slug="demo",
         title="Demo Template",
         description="Simple demo",
+        intended_use="demo",
+        io_contract={"input": "text", "output": "text"},
+        tools=[],
+        guardrails=[],
+        model_pref="gpt3",
         category=TemplateCategory.CONVERSATION,
         complexity=TemplateComplexity.BASIC,
+        created_by="tester",
+        semver="0.1.0",
+        last_test_passed="2024-01-01T00:00:00Z",
         tags=["demo"],
     )
 

--- a/tests/test_template_mixer.py
+++ b/tests/test_template_mixer.py
@@ -13,8 +13,16 @@ def _meta(slug: str) -> TemplateMetadata:
         slug=slug,
         title=slug,
         description="demo",
+        intended_use="demo",
+        io_contract={"input": "text", "output": "text"},
+        tools=[],
+        guardrails=[],
+        model_pref="gpt3",
         category=TemplateCategory.CONVERSATION,
         complexity=TemplateComplexity.BASIC,
+        created_by="tester",
+        semver="0.1.0",
+        last_test_passed="2024-01-01T00:00:00Z",
     )
 
 

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -11,8 +11,16 @@ def _meta() -> TemplateMetadata:
         slug="greet",
         title="Greeting",
         description="Say hi",
+        intended_use="demo",
+        io_contract={"input": "text", "output": "text"},
+        tools=[],
+        guardrails=[],
+        model_pref="gpt3",
         category=TemplateCategory.CONVERSATION,
         complexity=TemplateComplexity.BASIC,
+        created_by="tester",
+        semver="0.1.0",
+        last_test_passed="2024-01-01T00:00:00Z",
         tags=["demo"],
     )
 

--- a/tests/test_template_schema.py
+++ b/tests/test_template_schema.py
@@ -12,9 +12,17 @@ def test_template_metadata_valid() -> None:
         slug="basic-chat",
         title="Basic Chat Bot",
         description="Minimal conversational agent",
+        intended_use="demo",
+        io_contract={"input": "text", "output": "text"},
+        tools=[],
+        guardrails=[],
+        model_pref="gpt3",
         category=TemplateCategory.CONVERSATION,
         subcategory="qa",
         complexity=TemplateComplexity.BASIC,
+        created_by="tester",
+        semver="0.1.0",
+        last_test_passed="2024-01-01T00:00:00Z",
         tags=["chat"],
     )
     assert meta.slug == "basic-chat"
@@ -29,9 +37,17 @@ def test_template_metadata_invalid_category() -> None:
             slug="bad",
             title="Bad",
             description="Bad",
+            intended_use="demo",
+            io_contract={"input": "", "output": ""},
+            tools=[],
+            guardrails=[],
+            model_pref="gpt3",
             category="invalid",  # type: ignore[arg-type]
             subcategory="x",
             complexity=TemplateComplexity.BASIC,
+            created_by="tester",
+            semver="0.1.0",
+            last_test_passed="2024-01-01T00:00:00Z",
         )
     except ValidationError:
         pass

--- a/tests/test_template_search.py
+++ b/tests/test_template_search.py
@@ -12,8 +12,16 @@ def _meta(slug: str, category: TemplateCategory) -> TemplateMetadata:
         slug=slug,
         title=slug.title(),
         description=f"Template {slug}",
+        intended_use="demo",
+        io_contract={"input": "text", "output": "text"},
+        tools=[],
+        guardrails=[],
+        model_pref="gpt3",
         category=category,
         complexity=TemplateComplexity.BASIC,
+        created_by="tester",
+        semver="0.1.0",
+        last_test_passed="2024-01-01T00:00:00Z",
         tags=[slug],
     )
 

--- a/tests/test_template_sharing.py
+++ b/tests/test_template_sharing.py
@@ -12,8 +12,16 @@ def _meta(slug: str) -> TemplateMetadata:
         slug=slug,
         title=slug,
         description="demo",
+        intended_use="demo",
+        io_contract={"input": "text", "output": "text"},
+        tools=[],
+        guardrails=[],
+        model_pref="gpt3",
         category=TemplateCategory.CONVERSATION,
         complexity=TemplateComplexity.BASIC,
+        created_by="tester",
+        semver="0.1.0",
+        last_test_passed="2024-01-01T00:00:00Z",
     )
 
 


### PR DESCRIPTION
## Summary
- extend `TemplateMetadata` with richer fields and new `IOContract` model
- parse extended metadata in `TemplateSharingManager`
- implement inheritance/including in `TemplateMixer`
- document new metadata fields
- adjust all template tests for new schema

## Testing
- `ruff check src/meta_agent/template_schema.py src/meta_agent/template_sharing.py src/meta_agent/__init__.py tests/test_template_schema.py tests/test_template_registry.py tests/test_template_creator.py tests/test_template_search.py tests/test_template_sharing.py tests/test_template_mixer.py`
- `black --check src/meta_agent/template_schema.py src/meta_agent/template_sharing.py src/meta_agent/__init__.py tests/test_template_schema.py tests/test_template_registry.py tests/test_template_creator.py tests/test_template_search.py tests/test_template_sharing.py tests/test_template_mixer.py`
- `mypy src/meta_agent/template_schema.py src/meta_agent/template_sharing.py src/meta_agent/__init__.py` *(fails: Cannot find implementation or library stub for module named "dotenv" etc.)*
- `pyright src/meta_agent/template_schema.py src/meta_agent/template_sharing.py src/meta_agent/__init__.py` *(fails: Argument of type "Unknown | Any | None" cannot be assigned)*
- `pytest tests/test_template_schema.py tests/test_template_registry.py tests/test_template_creator.py tests/test_template_search.py tests/test_template_sharing.py tests/test_template_mixer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_683c3f03345c832fb75adc9ed436432b