### PR TITLE
feat: add template governance

### DIFF
--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -27,6 +27,7 @@ from .template_creator import TemplateCreator, validate_template
 from .template_mixer import TemplateMixer
 from .template_validator import TemplateValidator, TemplateTestCase
 from .template_sharing import TemplateSharingManager
+from .template_governance import TemplateGovernance
 
 # Expose `patch` globally for tests that forget to import it.
 try:
@@ -76,4 +77,5 @@ __all__ = [
     "TemplateValidator",
     "TemplateTestCase",
     "TemplateSharingManager",
+    "TemplateGovernance",
 ]

--- a/src/meta_agent/template_governance.py
+++ b/src/meta_agent/template_governance.py
@@ -1,0 +1,103 @@
+"""Template signing, verification and linting utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from jinja2 import Environment
+
+from .sandbox.sandbox_manager import SandboxExecutionError, SandboxManager
+from .template_validator import TemplateValidator
+
+
+class TemplateGovernance:
+    """Manage template trust by signing and verifying content."""
+
+    def __init__(
+        self,
+        cache_dir: str | Path = "template_cache",
+        *,
+        validator: TemplateValidator | None = None,
+        sandbox_manager: SandboxManager | None = None,
+    ) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.validator = validator or TemplateValidator()
+        self._sandbox_manager = sandbox_manager
+        self.signatures_path = self.cache_dir / "signatures.json"
+        self._signatures: Dict[str, str] = self._load_signatures()
+
+    # ------------------------------------------------------------------
+    def _load_signatures(self) -> Dict[str, str]:
+        try:
+            with open(self.signatures_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (OSError, json.JSONDecodeError):  # pragma: no cover - empty/invalid
+            return {}
+
+    def _save_signatures(self) -> None:
+        with open(self.signatures_path, "w", encoding="utf-8") as f:
+            json.dump(self._signatures, f, indent=2)
+
+    # ------------------------------------------------------------------
+    def sign_template(self, content: str) -> str:
+        """Return sha256 signature for ``content`` and cache it."""
+        signature = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        self._signatures[signature] = content
+        self._save_signatures()
+        return signature
+
+    def verify_template(self, content: str, signature: str) -> bool:
+        """Check if ``content`` matches the cached ``signature``."""
+        cached = self._signatures.get(signature)
+        if not cached:
+            return False
+        return hashlib.sha256(content.encode("utf-8")).hexdigest() == signature
+
+    # ------------------------------------------------------------------
+    def lint_template(self, content: str) -> bool:
+        """Run ``ruff`` on the provided Python code."""
+        tmp = self.cache_dir / "lint_temp.py"
+        tmp.write_text(content, encoding="utf-8")
+        try:
+            result = subprocess.run(
+                ["ruff", "check", str(tmp)],
+                capture_output=True,
+                text=True,
+            )
+            return result.returncode == 0
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    def _get_sandbox_manager(self) -> SandboxManager:
+        if self._sandbox_manager is None:
+            self._sandbox_manager = SandboxManager()
+        return self._sandbox_manager
+
+    def run_unsigned_template(
+        self,
+        content: str,
+        context: Optional[Dict[str, Any]] = None,
+        *,
+        timeout: int = 10,
+    ) -> str:
+        """Render ``content`` and run the result inside a sandbox."""
+        env = Environment()
+        template = env.from_string(content)
+        rendered = template.render(**(context or {}))
+        tmp_dir = self.cache_dir / "sandbox"
+        tmp_dir.mkdir(exist_ok=True)
+        script_path = tmp_dir / "script.py"
+        script_path.write_text(rendered, encoding="utf-8")
+        manager = self._get_sandbox_manager()
+        exit_code, out, err = manager.run_code_in_sandbox(
+            tmp_dir, ["python", script_path.name], timeout=timeout
+        )
+        if exit_code != 0:
+            raise SandboxExecutionError(err or "non-zero exit code")
+        return out

--- a/tests/test_template_governance.py
+++ b/tests/test_template_governance.py
@@ -1,0 +1,27 @@
+from meta_agent.template_governance import TemplateGovernance
+
+
+def test_sign_and_verify(tmp_path):
+    gov = TemplateGovernance(cache_dir=tmp_path)
+    content = "print('hi')"
+    sig = gov.sign_template(content)
+    assert gov.verify_template(content, sig)
+    assert not gov.verify_template("print('bye')", sig)
+
+
+def test_lint_template(tmp_path):
+    gov = TemplateGovernance(cache_dir=tmp_path)
+    good = "def foo():\n    pass\n"
+    bad = "from typing import *\n"
+    assert gov.lint_template(good)
+    assert not gov.lint_template(bad)
+
+
+def test_run_unsigned_template(tmp_path):
+    class FakeSandbox:
+        def run_code_in_sandbox(self, code_directory, command, **kwargs):
+            return 0, "ok", ""
+
+    gov = TemplateGovernance(cache_dir=tmp_path, sandbox_manager=FakeSandbox())
+    out = gov.run_unsigned_template("print('hello')")
+    assert out == "ok"


### PR DESCRIPTION
## Summary
- add `TemplateGovernance` module for template signing, linting, and sandboxed execution
- expose `TemplateGovernance` in `meta_agent.__init__`
- test template governance utilities

## Testing
- `ruff check src/meta_agent/template_governance.py tests/test_template_governance.py src/meta_agent/__init__.py`
- `black --check src/meta_agent/template_governance.py tests/test_template_governance.py src/meta_agent/__init__.py`
- `pytest tests/test_template_governance.py -q`
- `mypy src/meta_agent/template_governance.py --ignore-missing-imports --explicit-package-bases` *(fails: Found 6 errors in 2 files)*
- `pyright src/meta_agent/template_governance.py`

------
https://chatgpt.com/codex/tasks/task_e_683c65731540832fba847d7e17515c30