### PR TITLE
feat: add template governance

### DIFF
--- a/src/meta_agent/__init__.py
+++ b/src/meta_agent/__init__.py
@@ -27,6 +27,7 @@ from .template_creator import TemplateCreator, validate_template
 from .template_mixer import TemplateMixer
 from .template_validator import TemplateValidator, TemplateTestCase
 from .template_sharing import TemplateSharingManager
+from .template_governance import TemplateGovernance
 
 # Expose `patch` globally for tests that forget to import it.
 try:
@@ -76,4 +77,5 @@ __all__ = [
     "TemplateValidator",
     "TemplateTestCase",
     "TemplateSharingManager",
+    "TemplateGovernance",
 ]

--- a/src/meta_agent/template_governance.py
+++ b/src/meta_agent/template_governance.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+# ruff: noqa: E402
+
+"""Simple governance helpers for user-provided templates."""
+
+import subprocess
+from typing import Optional
+
+try:
+    from ruff.__main__ import find_ruff_bin
+except Exception:  # pragma: no cover - ruff very unlikely missing
+
+    def find_ruff_bin() -> str:  # type: ignore
+        return "ruff"
+
+
+class TemplateGovernance:
+    """Validate template code using Ruff."""
+
+    def __init__(self, ruff_path: Optional[str] = None) -> None:
+        self.ruff_path = ruff_path or find_ruff_bin()
+
+    def lint_template(self, content: str) -> bool:
+        """Return ``True`` if ``content`` passes Ruff linting."""
+        try:
+            result = subprocess.run(
+                [self.ruff_path, "check", "-", "--quiet", "--no-cache"],
+                input=content,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False

--- a/tests/test_template_governance.py
+++ b/tests/test_template_governance.py
@@ -1,0 +1,11 @@
+from meta_agent.template_governance import TemplateGovernance
+
+
+def test_lint_template() -> None:
+    gov = TemplateGovernance()
+    assert gov.lint_template("def foo():\n    pass\n")
+
+
+def test_lint_template_failure() -> None:
+    gov = TemplateGovernance()
+    assert not gov.lint_template("def foo(:\n    pass\n")


### PR DESCRIPTION
## Summary
- add `TemplateGovernance` for linting template code with Ruff
- expose `TemplateGovernance` in package init
- test the linting behaviour

## Testing
- `ruff check src/meta_agent/template_governance.py tests/test_template_governance.py`
- `black --check src/meta_agent/template_governance.py tests/test_template_governance.py`
- `pyright src/meta_agent/template_governance.py tests/test_template_governance.py`
- `pytest tests/test_template_governance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_683dc4d75e7c832f966e50a2a07add8c