### PR TITLE
feat: add template security scanning

### DIFF
--- a/src/meta_agent/template_creator.py
+++ b/src/meta_agent/template_creator.py
@@ -4,26 +4,30 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 
-from jinja2 import Environment, TemplateSyntaxError
+
+from .template_validator import TemplateValidator
 
 from .template_registry import TemplateRegistry
 from .template_schema import TemplateMetadata
 
 
 def validate_template(content: str) -> Tuple[bool, str]:
-    """Check that the template is valid Jinja2."""
-    try:
-        Environment().parse(content)
-    except TemplateSyntaxError as e:  # pragma: no cover - jinja2 handled
-        return False, str(e)
-    return True, ""
+    """Check that the template is valid Jinja2 and passes security scan."""
+    validator = TemplateValidator()
+    result = validator.validate(content)
+    return result.success, "; ".join(result.errors)
 
 
 class TemplateCreator:
     """Create and register templates."""
 
-    def __init__(self, registry: Optional[TemplateRegistry] = None) -> None:
+    def __init__(
+        self,
+        registry: Optional[TemplateRegistry] = None,
+        validator: Optional[TemplateValidator] = None,
+    ) -> None:
         self.registry = registry or TemplateRegistry()
+        self.validator = validator or TemplateValidator()
 
     def create(
         self,
@@ -35,9 +39,11 @@ class TemplateCreator:
     ) -> Optional[str]:
         """Register a template after optional validation."""
         if validate:
-            ok, err = validate_template(content)
-            if not ok:
-                raise ValueError(f"Template validation failed: {err}")
+            result = self.validator.validate(content, metadata=metadata)
+            if not result.success:
+                raise ValueError(
+                    "Template validation failed: " + "; ".join(result.errors)
+                )
         if not content.strip():
             raise ValueError("Template content cannot be empty")
         return self.registry.register(metadata, content, version)

--- a/src/meta_agent/template_validator.py
+++ b/src/meta_agent/template_validator.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 import time
+import re
 
 from jinja2 import Environment, TemplateSyntaxError, meta
+
+from .dependency_manager import DependencyManager
+from .template_schema import TemplateMetadata
 
 from .models.validation_result import ValidationResult
 
@@ -22,8 +26,43 @@ class TemplateTestCase:
 class TemplateValidator:
     """Validate templates via syntax and optional test cases."""
 
-    def __init__(self, env: Optional[Environment] = None) -> None:
+    def __init__(
+        self,
+        env: Optional[Environment] = None,
+        dep_manager: Optional[DependencyManager] = None,
+    ) -> None:
         self.env = env or Environment()
+        self.dep_manager = dep_manager or DependencyManager()
+
+    _SHELL_PATTERNS = [
+        (r"os\.system\(", "os.system usage"),
+        (r"subprocess\.", "subprocess usage"),
+        (r"`.+?`", "shell backticks"),
+        (r"shell=True", "shell=True"),
+    ]
+
+    _DISALLOWED_LICENSES = {"GPL", "AGPL"}
+
+    def _scan_shell_commands(self, content: str) -> List[str]:
+        issues: List[str] = []
+        for pattern, desc in self._SHELL_PATTERNS:
+            if re.search(pattern, content):
+                issues.append(f"shell command detected: {desc}")
+        return issues
+
+    def _scan_licenses(self, metadata: TemplateMetadata) -> List[str]:
+        issues: List[str] = []
+        if not metadata.tools:
+            return issues
+        try:
+            _, licenses, _ = self.dep_manager.resolve(metadata.tools)
+        except Exception as exc:  # pragma: no cover - dependency errors rare
+            issues.append(f"dependency resolution failed: {exc}")
+            return issues
+        for pkg, lic in licenses.items():
+            if any(tag in lic for tag in self._DISALLOWED_LICENSES):
+                issues.append(f"non-permissive license for {pkg}: {lic}")
+        return issues
 
     def validate(
         self,
@@ -31,6 +70,7 @@ class TemplateValidator:
         test_cases: Optional[List[TemplateTestCase]] = None,
         *,
         max_render_seconds: float = 1.0,
+        metadata: Optional[TemplateMetadata] = None,
     ) -> ValidationResult:
         """Validate ``content`` and optionally run ``test_cases``."""
         errors: List[str] = []
@@ -58,5 +98,11 @@ class TemplateValidator:
                     and output.strip() != case.expected_output.strip()
                 ):
                     errors.append("output mismatch")
+
+        # security scans -------------------------------------------------
+        errors.extend(self._scan_shell_commands(content))
+        if metadata is not None:
+            errors.extend(self._scan_licenses(metadata))
+
         success = not errors
         return ValidationResult(success=success, errors=errors, coverage=0.0)


### PR DESCRIPTION
## Summary
- implement shell command and license scanning in `TemplateValidator`
- integrate enhanced validation into `TemplateCreator`
- test new security features in validator

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 47 files)*
- `pytest` *(fails: 29 failed, 17 errors)*
- `mypy src/meta_agent` *(fails: Found 53 errors)*
- `pyright` *(fails: 101 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68405c8a3394832fa91f3dcc5a0f8d89