### PR TITLE
docs: design diagram and UX modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Generate production-ready agents in minutes, with built-in validation, sandboxin
 *   **Guardrail Designer sub-agent:** Creates validation logic (Pydantic, regex, policy checks) and guardrail tests, embedding safety and compliance early to prevent bad outputs. See [docs/guardrail_designer_guide.md](docs/guardrail_designer_guide.md) for details.
 *   **Automated evaluation harness:** Compiles generated code, executes unit tests, and surfaces results, guaranteeing that the agent "actually runs." See [docs/evaluation_harness_architecture.md](docs/evaluation_harness_architecture.md) for the design.
 *   **Artifact bundle & dependency lock:** Outputs `agent.py`, `tests/`, `requirements.txt`, and an optional diagram. This allows for one-command install and run, ensuring reproducible builds.
+*   **Diagram & UX modules:** Handle Mermaid diagram generation, coloured CLI output, and interactive prompts. See [docs/diagram_cli_architecture.md](docs/diagram_cli_architecture.md) for the design.
 *   **Cost & trace telemetry:** Logs token usage, latency, and spend per generation, helping to manage cloud costs and aid optimization. See [docs/telemetry_overview.md](docs/telemetry_overview.md) for details.
 *   See [docs/telemetry_roadmap.md](docs/telemetry_roadmap.md) for the telemetry development roadmap.
 

--- a/docs/diagram_cli_architecture.md
+++ b/docs/diagram_cli_architecture.md
@@ -1,0 +1,47 @@
+# Diagram, CLI Output, and Interactive Modules Architecture
+
+## 1. Overview
+
+This design separates user experience features into three dedicated modules. Diagram generation, terminal output, and interactive prompts remain independent so they can evolve without tightly coupling concerns. Each module exposes a minimal interface to make integration and testing straightforward.
+
+## 2. Modules
+
+### Diagram Module
+- Generates Mermaid diagrams describing agent architecture.
+- Accepts an agent specification or internal representation.
+- Exposes `generate(spec: dict) -> str` returning Mermaid syntax.
+- Handles customization such as node styles and colors.
+
+### CLI Output Module
+- Centralises all formatted terminal output.
+- Provides helpers for info, warning, error, and progress messages.
+- Adds optional colour support and verbosity levels.
+
+### Interactive Module
+- Manages user prompts for refining specifications.
+- Supports menus and free‑form questions.
+- Exposes `ask(prompt: str) -> str` for synchronous usage.
+
+### UX Orchestrator
+- Coordinates the above modules.
+- Ensures diagrams and progress updates reach the user consistently.
+
+## 3. Data Flow Diagram
+
+```mermaid
+flowchart LR
+    SPEC["Specification"] --> UXO["UX Orchestrator"]
+    UXO --> CLI["CLI Output"]
+    UXO --> DIA["Diagram Module"]
+    UXO --> INT["Interactive Module"]
+    DIA --> CLI
+    INT --> CLI
+    CLI --> USER["User"]
+```
+
+## 4. Dependency Management
+
+Each module lives under `src/meta_agent/ux/` to keep UX concerns isolated. They
+should only depend on lightweight utilities and avoid coupling to the core
+planning engine. This keeps testing simple and allows future replacement with
+alternative implementations, such as a graphical UI.


### PR DESCRIPTION
## Summary
- add architecture doc for diagram generation and CLI/interactive UX modules
- reference the new doc in README

## Testing
- `ruff check .` *(fails: F401 errors)*
- `black --check .` *(fails: would reformat many files)*
- `pytest -q` *(fails: ImportError and other errors)*
- `mypy src/meta_agent` *(fails: several typing errors)*
- `pyright` *(fails: numerous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68441aa31eb8832f9ad0bbd880be4225