### PR TITLE
feat: add CLI output module

### DIFF
--- a/src/meta_agent/ux/__init__.py
+++ b/src/meta_agent/ux/__init__.py
@@ -1,5 +1,6 @@
 """User experience modules for diagram generation and CLI output."""
 
 from .diagram_generator import DiagramGenerator, DiagramGenerationError
+from .cli_output import CLIOutput
 
-__all__ = ["DiagramGenerator", "DiagramGenerationError"]
+__all__ = ["DiagramGenerator", "DiagramGenerationError", "CLIOutput"]

--- a/src/meta_agent/ux/cli_output.py
+++ b/src/meta_agent/ux/cli_output.py
@@ -1,0 +1,44 @@
+"""Utilities for consistent CLI output with colors and verbosity levels."""
+
+from __future__ import annotations
+
+import click
+
+
+class CLIOutput:
+    """Manage colored terminal output with verbosity control."""
+
+    def __init__(self, verbosity: int = 1) -> None:
+        self.verbosity = verbosity
+
+    def set_verbosity(self, verbosity: int) -> None:
+        """Set the current verbosity level."""
+        self.verbosity = verbosity
+
+    def _echo(
+        self,
+        message: str,
+        *,
+        fg: str | None = None,
+        bold: bool = False,
+        err: bool = False,
+        level: int = 1,
+    ) -> None:
+        if self.verbosity >= level:
+            click.secho(message, fg=fg, bold=bold, err=err)
+
+    def info(self, message: str, *, level: int = 1) -> None:
+        """Output an informational message."""
+        self._echo(message, fg="cyan", level=level)
+
+    def success(self, message: str, *, level: int = 1) -> None:
+        """Output a success message."""
+        self._echo(message, fg="green", bold=True, level=level)
+
+    def warning(self, message: str, *, level: int = 1) -> None:
+        """Output a warning message."""
+        self._echo(message, fg="yellow", level=level)
+
+    def error(self, message: str, *, level: int = 1) -> None:
+        """Output an error message."""
+        self._echo(message, fg="red", bold=True, err=True, level=level)

--- a/tests/ux/test_cli_output.py
+++ b/tests/ux/test_cli_output.py
@@ -1,0 +1,28 @@
+import click
+from meta_agent.ux import CLIOutput
+
+
+def test_info_output(capsys):
+    cli = CLIOutput()
+    cli.info("hello")
+    out, err = capsys.readouterr()
+    assert "hello" in click.unstyle(out)
+    assert err == ""
+
+
+def test_verbosity_levels(capsys):
+    cli = CLIOutput(verbosity=0)
+    cli.info("quiet")
+    out, err = capsys.readouterr()
+    assert out == "" and err == ""
+    cli.info("force", level=0)
+    out, _ = capsys.readouterr()
+    assert "force" in click.unstyle(out)
+
+
+def test_error_output_stderr(capsys):
+    cli = CLIOutput()
+    cli.error("oops")
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert "oops" in click.unstyle(err)


### PR DESCRIPTION
## Summary
- implement CLIOutput for colored terminal messages
- export CLIOutput
- test CLIOutput behaviours

## Testing
- `ruff check src/meta_agent/ux/cli_output.py tests/ux/test_cli_output.py`
- `black --check src/meta_agent/ux/cli_output.py tests/ux/test_cli_output.py`
- `pytest -v tests/ux/test_cli_output.py tests/ux/test_diagram_generator.py`
- `mypy src/meta_agent`
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_6844e41fad5c832fa3c5da0f1d27459f