### PR TITLE
feat: add interactive ux module

### DIFF
--- a/src/meta_agent/ux/__init__.py
+++ b/src/meta_agent/ux/__init__.py
@@ -1,6 +1,12 @@
-"""User experience modules for diagram generation and CLI output."""
+"""User experience modules for diagram generation, CLI output and prompts."""
 
 from .diagram_generator import DiagramGenerator, DiagramGenerationError
 from .cli_output import CLIOutput
+from .interactive import Interactive
 
-__all__ = ["DiagramGenerator", "DiagramGenerationError", "CLIOutput"]
+__all__ = [
+    "DiagramGenerator",
+    "DiagramGenerationError",
+    "CLIOutput",
+    "Interactive",
+]

--- a/src/meta_agent/ux/interactive.py
+++ b/src/meta_agent/ux/interactive.py
@@ -1,0 +1,36 @@
+"""Interactive prompt utilities for user input and menus."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+class Interactive:
+    """Handle user prompts and interactive menus."""
+
+    def ask(self, prompt: str) -> str:
+        """Return a response to the given prompt."""
+        return input(f"{prompt.strip()} ")
+
+    def menu(self, prompt: str, options: Sequence[str]) -> str:
+        """Display a numbered menu and return the selected option."""
+        if not options:
+            raise ValueError("options must not be empty")
+
+        while True:
+            print(prompt)
+            for idx, opt in enumerate(options, 1):
+                print(f"{idx}. {opt}")
+            choice = self.ask("Choose an option:")
+            if choice.isdigit():
+                selected = int(choice) - 1
+                if 0 <= selected < len(options):
+                    return options[selected]
+            print("Invalid choice, try again.")
+
+    def form(self, fields: Sequence[str]) -> dict[str, str]:
+        """Prompt for multiple fields and return a mapping of answers."""
+        responses: dict[str, str] = {}
+        for field in fields:
+            responses[field] = self.ask(f"{field}:")
+        return responses

--- a/tests/ux/test_interactive.py
+++ b/tests/ux/test_interactive.py
@@ -1,0 +1,25 @@
+from meta_agent.ux import Interactive
+
+
+def test_ask(monkeypatch):
+    inter = Interactive()
+    monkeypatch.setattr("builtins.input", lambda _: "answer")
+    assert inter.ask("Question?") == "answer"
+
+
+def test_menu(monkeypatch, capsys):
+    inputs = iter(["3", "2"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    inter = Interactive()
+    result = inter.menu("Pick one", ["a", "b"])
+    out = capsys.readouterr().out
+    assert "Invalid choice" in out
+    assert result == "b"
+
+
+def test_form(monkeypatch):
+    inputs = iter(["foo", "bar"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    inter = Interactive()
+    result = inter.form(["first", "second"])
+    assert result == {"first": "foo", "second": "bar"}


### PR DESCRIPTION
## Summary
- add `Interactive` prompt utilities module
- expose new Interactive class in ux package
- test the Interactive module functions

## Testing
- `ruff check . | head -n 5`
- `black --check src/meta_agent/ux/interactive.py tests/ux/test_interactive.py`
- `mypy src/meta_agent/ux/interactive.py tests/ux/test_interactive.py --ignore-missing-imports | head`
- `pyright src/meta_agent/ux/interactive.py tests/ux/test_interactive.py | head`
- `pytest -v tests/ux/test_interactive.py | head`


------
https://chatgpt.com/codex/tasks/task_e_6844e81b7294832f8458670dfde95636