### PR TITLE
feat: add ux error handling

### DIFF
--- a/src/meta_agent/registry.py
+++ b/src/meta_agent/registry.py
@@ -231,6 +231,7 @@ class ToolRegistry:
                 spec = importlib.util.spec_from_file_location(
                     pkg_name, self.tools_dir / "__init__.py"
                 )
+                assert spec is not None
                 pkg = importlib.util.module_from_spec(spec)
                 sys.modules[pkg_name] = pkg
                 pkg.__path__ = [pkg_path]

--- a/src/meta_agent/ux/__init__.py
+++ b/src/meta_agent/ux/__init__.py
@@ -1,12 +1,23 @@
 """User experience modules for diagram generation, CLI output and prompts."""
 
-from .diagram_generator import DiagramGenerator, DiagramGenerationError
+from .diagram_generator import DiagramGenerator
 from .cli_output import CLIOutput
 from .interactive import Interactive
+from .error_handler import (
+    DiagramGenerationError,
+    ErrorHandler,
+    UXError,
+    CLIOutputError,
+    InteractiveError,
+)
 
 __all__ = [
     "DiagramGenerator",
     "DiagramGenerationError",
+    "ErrorHandler",
+    "UXError",
+    "CLIOutputError",
+    "InteractiveError",
     "CLIOutput",
     "Interactive",
 ]

--- a/src/meta_agent/ux/cli_output.py
+++ b/src/meta_agent/ux/cli_output.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import click
 
+from .error_handler import CLIOutputError
+
 
 class CLIOutput:
     """Manage colored terminal output with verbosity control."""
@@ -25,7 +27,12 @@ class CLIOutput:
         level: int = 1,
     ) -> None:
         if self.verbosity >= level:
-            click.secho(message, fg=fg, bold=bold, err=err)
+            try:
+                click.secho(message, fg=fg, bold=bold, err=err)
+            except Exception as e:  # pragma: no cover - extremely unlikely
+                raise CLIOutputError(
+                    "failed to write output", context={"message": message}
+                ) from e
 
     def info(self, message: str, *, level: int = 1) -> None:
         """Output an informational message."""

--- a/src/meta_agent/ux/diagram_generator.py
+++ b/src/meta_agent/ux/diagram_generator.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from typing import Mapping, Any
 
-
-class DiagramGenerationError(Exception):
-    """Raised when diagram generation fails."""
+from .error_handler import DiagramGenerationError
 
 
 class DiagramGenerator:

--- a/src/meta_agent/ux/error_handler.py
+++ b/src/meta_agent/ux/error_handler.py
@@ -1,0 +1,64 @@
+"""Central error handling utilities for UX modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Any, TYPE_CHECKING
+
+import logging
+
+from meta_agent.utils.logging import setup_logging
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .cli_output import CLIOutput
+
+logger = setup_logging(__name__)
+
+
+@dataclass
+class UXError(Exception):
+    """Base error with optional context."""
+
+    message: str
+    context: Mapping[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class CLIOutputError(UXError):
+    """Raised when CLI output fails."""
+
+
+class InteractiveError(UXError):
+    """Raised when interactive input fails."""
+
+
+class DiagramGenerationError(UXError):
+    """Raised when diagram generation fails."""
+
+
+class ErrorHandler:
+    """Handle errors by logging and providing user feedback."""
+
+    def __init__(
+        self,
+        cli_output: CLIOutput | None = None,
+        log: logging.Logger | None = None,
+    ) -> None:
+        from .cli_output import CLIOutput  # local import to avoid circular
+
+        self.cli_output = cli_output or CLIOutput()
+        self.logger = log or logger
+
+    def handle(self, error: UXError) -> None:
+        """Log the error and display the message via CLI."""
+        msg = str(error)
+        if error.context:
+            self.logger.error("%s | context=%s", msg, error.context)
+        else:
+            self.logger.error(msg)
+        try:
+            self.cli_output.error(msg)
+        except Exception:
+            self.logger.error("Failed to output error message via CLI")

--- a/src/meta_agent/ux/interactive.py
+++ b/src/meta_agent/ux/interactive.py
@@ -4,18 +4,23 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from .error_handler import InteractiveError
+
 
 class Interactive:
     """Handle user prompts and interactive menus."""
 
     def ask(self, prompt: str) -> str:
         """Return a response to the given prompt."""
-        return input(f"{prompt.strip()} ")
+        try:
+            return input(f"{prompt.strip()} ")
+        except (EOFError, KeyboardInterrupt) as e:  # pragma: no cover - user interrupt
+            raise InteractiveError("input interrupted") from e
 
     def menu(self, prompt: str, options: Sequence[str]) -> str:
         """Display a numbered menu and return the selected option."""
         if not options:
-            raise ValueError("options must not be empty")
+            raise InteractiveError("options must not be empty")
 
         while True:
             print(prompt)

--- a/tests/ux/test_cli_output.py
+++ b/tests/ux/test_cli_output.py
@@ -1,5 +1,6 @@
 import click
-from meta_agent.ux import CLIOutput
+import pytest
+from meta_agent.ux import CLIOutput, CLIOutputError
 
 
 def test_info_output(capsys):
@@ -26,3 +27,13 @@ def test_error_output_stderr(capsys):
     out, err = capsys.readouterr()
     assert out == ""
     assert "oops" in click.unstyle(err)
+
+
+def test_cli_output_error(monkeypatch):
+    def fail(*args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(click, "secho", fail)
+    cli = CLIOutput()
+    with pytest.raises(CLIOutputError):
+        cli.info("hello")

--- a/tests/ux/test_error_handler.py
+++ b/tests/ux/test_error_handler.py
@@ -1,0 +1,24 @@
+import logging
+
+from meta_agent.ux import (
+    CLIOutput,
+    ErrorHandler,
+    CLIOutputError,
+    UXError,
+    DiagramGenerationError,
+)
+
+
+def test_error_handler_logs_and_outputs(caplog, capsys):
+    handler = ErrorHandler(cli_output=CLIOutput())
+    err = CLIOutputError("boom", context={"foo": "bar"})
+    with caplog.at_level(logging.ERROR):
+        handler.handle(err)
+    out, err_stream = capsys.readouterr()
+    assert "boom" in err_stream
+    assert "boom" in caplog.text
+    assert "foo" in caplog.text
+
+
+def test_diagram_generation_error_subclass():
+    assert issubclass(DiagramGenerationError, UXError)

--- a/tests/ux/test_interactive.py
+++ b/tests/ux/test_interactive.py
@@ -1,4 +1,5 @@
-from meta_agent.ux import Interactive
+import pytest
+from meta_agent.ux import Interactive, InteractiveError
 
 
 def test_ask(monkeypatch):
@@ -23,3 +24,19 @@ def test_form(monkeypatch):
     inter = Interactive()
     result = inter.form(["first", "second"])
     assert result == {"first": "foo", "second": "bar"}
+
+
+def test_menu_empty_options():
+    inter = Interactive()
+    with pytest.raises(InteractiveError):
+        inter.menu("Pick", [])
+
+
+def test_ask_interrupt(monkeypatch):
+    def raise_interrupt(_):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_interrupt)
+    inter = Interactive()
+    with pytest.raises(InteractiveError):
+        inter.ask("Question")


### PR DESCRIPTION
## Summary
- implement unified UX error handling
- add CLIOutput and Interactive error classes
- update diagram generator to import new error type
- test the error handling functionality

## Testing
- `ruff check src/meta_agent/ux tests/ux`
- `black --check src/meta_agent/ux tests/ux`
- `mypy src/meta_agent/ux tests/ux --exclude 'src/meta_agent/__init__\.py'` *(fails: Argument 1 to "module_from_spec" has incompatible type "ModuleSpec | None"; expected "ModuleSpec" [arg-type])* 
- `pyright src/meta_agent/ux tests/ux`
- `pytest -v tests/ux`

------
https://chatgpt.com/codex/tasks/task_e_6844ed407bbc832fa08de9d5096e6a27