### PR TITLE
fix: assert spec before module import

### DIFF
--- a/meta_agent/__init__.py
+++ b/meta_agent/__init__.py
@@ -6,6 +6,7 @@ _src = Path(__file__).resolve().parent.parent / "src" / "meta_agent" / "__init__
 _spec = spec_from_file_location(
     "meta_agent", _src, submodule_search_locations=[str(_src.parent)]
 )
+assert _spec is not None
 _module = module_from_spec(_spec)
 sys.modules[__name__] = _module
 _spec.loader.exec_module(_module)  # type: ignore


### PR DESCRIPTION
## Summary
- guard against None from `spec_from_file_location`

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 57 files)*
- `pytest`
- `mypy src/meta_agent` *(fails: several type errors)*
- `pyright` *(fails: 119 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847070aeb64832fa134144c615bbc75