### PR TITLE
chore: silence pytest mock attr check

### DIFF
--- a/pytest_asyncio_config.py
+++ b/pytest_asyncio_config.py
@@ -7,7 +7,7 @@ def pytest_configure(config):
     # Also register the simple mocker fixture from our local pytest_mock module
     if not config.pluginmanager.hasplugin("pytest_mock"):
         try:
-            pytest_mock.pytest_configure(config)
+            pytest_mock.pytest_configure(config)  # type: ignore[attr-defined]
         except Exception:  # pragma: no cover - ignore if already registered
             pass
 


### PR DESCRIPTION
## Summary
- ignore static attr check when calling pytest_mock.pytest_configure

## Testing
- `ruff check .`
- `black --check pytest_asyncio_config.py`
- `pytest -v tests`
- `mypy src/meta_agent tests` *(fails: Missing stubs and duplicate module names)*
- `pyright` *(fails: numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847070e01cc832fb6836191a0c4e9e1