### PR TITLE
fix: support pydantic v1 field validators

### DIFF
--- a/src/meta_agent/generators/guardrail_generator.py
+++ b/src/meta_agent/generators/guardrail_generator.py
@@ -6,10 +6,12 @@ from enum import Enum
 import re
 from typing import Awaitable, Callable, List
 
+from pydantic import BaseModel, Field
+
 try:
-    from pydantic import BaseModel, Field, field_validator
-except ImportError:  # pragma: no cover - pydantic v1 fallback
-    from pydantic import BaseModel, Field, validator as field_validator
+    from pydantic import field_validator
+except ImportError:  # Pydantic v1
+    from pydantic import validator as field_validator
 
 
 class GuardrailAction(str, Enum):

--- a/src/meta_agent/models/spec_schema.py
+++ b/src/meta_agent/models/spec_schema.py
@@ -2,10 +2,12 @@ import json
 import yaml
 from pathlib import Path
 
+from pydantic import BaseModel, Field, ValidationError
+
 try:
-    from pydantic import BaseModel, Field, field_validator, ValidationError
-except ImportError:  # pragma: no cover - pydantic v1 fallback
-    from pydantic import BaseModel, Field, ValidationError, validator as field_validator
+    from pydantic import field_validator
+except ImportError:  # Pydantic v1
+    from pydantic import validator as field_validator
 from typing import Optional, Dict, List, Any, Union
 
 

--- a/src/meta_agent/parsers/tool_spec_parser.py
+++ b/src/meta_agent/parsers/tool_spec_parser.py
@@ -2,12 +2,14 @@ import json
 import yaml
 import textwrap
 
+from pydantic import BaseModel, Field, ValidationError
+
 try:
-    from pydantic import BaseModel, Field, ValidationError, ConfigDict, field_validator
+    from pydantic import ConfigDict, field_validator
 
     _HAS_V2 = True
-except ImportError:  # pragma: no cover - pydantic v1 fallback
-    from pydantic import BaseModel, Field, ValidationError, validator as field_validator
+except ImportError:  # Pydantic v1
+    from pydantic import validator as field_validator
 
     _HAS_V2 = False
 


### PR DESCRIPTION
## Summary
- import `field_validator` with backward compatibility for pydantic v1
- clean up duplicate imports

## Testing
- `ruff check .`
- `black --check src/meta_agent/generators/guardrail_generator.py src/meta_agent/models/spec_schema.py src/meta_agent/parsers/tool_spec_parser.py`
- `mypy src/meta_agent` *(fails: Argument 1 has incompatible type "Any | None"; expected "str")*
- `pyright src/meta_agent` *(fails: `field_validator` is unknown import symbol)*
- `pytest tests/test_spec_schema.py::test_spec_schema_instantiation -q`

------
https://chatgpt.com/codex/tasks/task_e_68470714ba94832fbf77c004b7816e05