### PR TITLE
refactor: use dataclass default_factory for lists

### DIFF
--- a/src/meta_agent/models/validation_result.py
+++ b/src/meta_agent/models/validation_result.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 
@@ -18,26 +18,16 @@ class ValidationResult:
     is_valid: bool = False
 
     # Detailed error information
-    syntax_errors: List[str] = None
-    security_issues: List[str] = None
-    compliance_issues: List[str] = None
+    syntax_errors: List[str] = field(default_factory=list)
+    security_issues: List[str] = field(default_factory=list)
+    compliance_issues: List[str] = field(default_factory=list)
     error_message: Optional[str] = None
 
     # For validation.py compatibility
     success: bool = False
-    errors: List[str] = None
+    errors: List[str] = field(default_factory=list)
     coverage: float = 0.0
 
-    def __post_init__(self):
-        """Initialize lists if they are None."""
-        if self.syntax_errors is None:
-            self.syntax_errors = []
-        if self.security_issues is None:
-            self.security_issues = []
-        if self.compliance_issues is None:
-            self.compliance_issues = []
-        if self.errors is None:
-            self.errors = []
 
     def update_validity(self):
         """


### PR DESCRIPTION
## Summary
- use `field(default_factory=list)` for list attributes in `ValidationResult`

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `pytest -v --cov=src/meta_agent tests` *(fails: unrecognized arguments)*
- `pip install -e .[test]` *(fails: could not find a version that satisfies the requirement hatchling)*
- `mypy src/meta_agent tests` *(fails: 4 errors)*
- `pyright` *(fails: 116 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68470715bb40832f9db866c667569596