### PR TITLE
refactor: explicitly import util module

### DIFF
--- a/src/meta_agent/registry.py
+++ b/src/meta_agent/registry.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import json
 import logging
 import shutil


### PR DESCRIPTION
## Summary
- import `importlib.util` in `registry.py`
- run ruff, black, mypy, pyright, pytest

## Testing
- `ruff check .`
- `black --check src/meta_agent/registry.py`
- `mypy src/meta_agent/registry.py` *(fails: Found 12 errors in 6 files)*
- `pyright src/meta_agent/registry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470717a930832f9b94c70c2ef48749