### PR TITLE
test: use typed metadata objects

### DIFF
--- a/tests/generators/test_tool_code_generator.py
+++ b/tests/generators/test_tool_code_generator.py
@@ -9,39 +9,57 @@ SPEC_SIMPLE = ToolSpecification(
     name="get_current_time",
     purpose="Gets the current system time.",
     input_parameters=[],
-    output_format="string"
+    output_format="string",
 )
 
 SPEC_WITH_PARAMS = ToolSpecification(
     name="get_stock_price",
     purpose="Fetches the current stock price for a given ticker symbol.",
     input_parameters=[
-        ToolParameter(name="ticker", type_="string", description="The stock ticker symbol (e.g., AAPL)", required=True),
-        ToolParameter(name="exchange", type_="string", description="The stock exchange (e.g., NASDAQ)", required=False)
+        ToolParameter(
+            name="ticker",
+            type_="string",
+            description="The stock ticker symbol (e.g., AAPL)",
+            required=True,
+        ),
+        ToolParameter(
+            name="exchange",
+            type_="string",
+            description="The stock exchange (e.g., NASDAQ)",
+            required=False,
+        ),
     ],
-    output_format="float"
+    output_format="float",
 )
 
 SPEC_LIST_PARAM = ToolSpecification(
     name="sum_numbers",
     purpose="Calculates the sum of a list of numbers.",
     input_parameters=[
-        ToolParameter(name="numbers", type_="list[float]", description="A list of numbers to sum.", required=True)
+        ToolParameter(
+            name="numbers",
+            type_="list[float]",
+            description="A list of numbers to sum.",
+            required=True,
+        )
     ],
-    output_format="float"
+    output_format="float",
 )
 
 SPEC_INVALID_SYNTAX_IN_PURPOSE = ToolSpecification(
     name="bad_tool",
     # Purpose contains syntax that might break the docstring if not handled
-    purpose='Fetches data using `SELECT * FROM table WHERE id = {id}`. It\'s tricky.',
+    purpose="Fetches data using `SELECT * FROM table WHERE id = {id}`. It's tricky.",
     input_parameters=[
-        ToolParameter(name="id", type_="integer", description="The ID to fetch.", required=True)
+        ToolParameter(
+            name="id", type_="integer", description="The ID to fetch.", required=True
+        )
     ],
-    output_format="dict"
+    output_format="dict",
 )
 
 # --- Test Cases ---
+
 
 def test_generate_simple_tool():
     """Tests generating a tool with no parameters."""
@@ -64,15 +82,16 @@ def test_generate_simple_tool():
     assert len(func_defs) == 1
     func_def = func_defs[0]
     assert func_def.name == "get_current_time"
-    assert not func_def.args.args # No arguments
-    assert func_def.returns.id == 'str' # Check return type hint
+    assert not func_def.args.args  # No arguments
+    assert func_def.returns.id == "str"  # Check return type hint
 
     # Check docstring content (basic)
     docstring = ast.get_docstring(func_def)
     assert docstring is not None
     assert "Gets the current system time." in docstring
     assert "Returns:" in docstring
-    assert "str: string" in docstring # Check return type in docstring
+    assert "str: string" in docstring  # Check return type in docstring
+
 
 def test_generate_tool_with_params():
     """Tests generating a tool with multiple parameters (required and optional)."""
@@ -95,23 +114,24 @@ def test_generate_tool_with_params():
 
     # Check parameters and type hints
     assert func_def.args.args[0].arg == "ticker"
-    assert func_def.args.args[0].annotation.id == 'str'
+    assert func_def.args.args[0].annotation.id == "str"
     assert func_def.args.args[1].arg == "exchange"
-    assert func_def.args.args[1].annotation.id == 'str'
+    assert func_def.args.args[1].annotation.id == "str"
 
     # Check optional parameter default (should be None)
     assert len(func_def.args.defaults) == 1
     assert isinstance(func_def.args.defaults[0], ast.Constant)
     assert func_def.args.defaults[0].value is None
 
-    assert func_def.returns.id == 'float'
+    assert func_def.returns.id == "float"
 
     # Check docstring params
     docstring = ast.get_docstring(func_def)
     assert docstring is not None
     assert "ticker: The stock ticker symbol (e.g., AAPL) (Required)" in docstring
     assert "exchange: The stock exchange (e.g., NASDAQ) (Optional)" in docstring
-    assert "float: float" in docstring # Check return type in docstring
+    assert "float: float" in docstring  # Check return type in docstring
+
 
 def test_generate_tool_with_list_param():
     """Tests generating a tool with a generic list parameter."""
@@ -136,16 +156,18 @@ def test_generate_tool_with_list_param():
     assert func_def.args.args[0].arg == "numbers"
     annotation = func_def.args.args[0].annotation
     assert isinstance(annotation, ast.Subscript)
-    assert annotation.value.id == 'List'
-    assert annotation.slice.id == 'float'
+    assert annotation.value.id == "List"
+    assert isinstance(annotation.slice, ast.Name)
+    assert annotation.slice.id == "float"
 
-    assert func_def.returns.id == 'float'
+    assert func_def.returns.id == "float"
 
     docstring = ast.get_docstring(func_def)
     assert docstring is not None
     assert "numbers: A list of numbers to sum. (Required)" in docstring
     assert "Returns:" in docstring
-    assert "float: float" in docstring # Check corrected return type in docstring
+    assert "float: float" in docstring  # Check corrected return type in docstring
+
 
 def test_generate_with_tricky_docstring():
     """Tests generating with characters in purpose/description that might break docstrings."""
@@ -172,4 +194,4 @@ def test_generate_with_tricky_docstring():
     assert "`SELECT * FROM table WHERE id = {id}`" in docstring
     assert "It's tricky." in docstring
     assert "id: The ID to fetch. (Required)" in docstring
-    assert "Dict: dict" in docstring # Check return type mapping
+    assert "Dict: dict" in docstring  # Check return type mapping

--- a/tests/integration/test_tool_lifecycle.py
+++ b/tests/integration/test_tool_lifecycle.py
@@ -26,10 +26,10 @@ def sample_tool_spec():
                 "name": "user_name",
                 "type": "string",
                 "description": "Name to greet",
-                "required": True
+                "required": True,
             }
         ],
-        "output_format": "string"
+        "output_format": "string",
     }
 
 
@@ -68,7 +68,8 @@ def components(tool_registry, mock_sandbox_manager):
 
     # Patch the SandboxManager - it might be imported conditionally
     with patch(
-        "meta_agent.sandbox.sandbox_manager.SandboxManager", return_value=mock_sandbox_manager
+        "meta_agent.sandbox.sandbox_manager.SandboxManager",
+        return_value=mock_sandbox_manager,
     ):
         yield {
             "planning_engine": planning_engine,
@@ -133,10 +134,10 @@ async def test_end_to_end_tool_creation(orchestrator, sample_tool_spec, tool_reg
     assert orchestrator.tool_generated_total == 1
 
     # 2. Check that the tool appears in the registry
-    tools_list = tool_registry.list_tools()
-    assert len(tools_list) == 1
-    assert tools_list[0]["name"] == sample_tool_spec["name"]
-    assert tools_list[0]["versions"][0]["version"] == "0.1.0"
+    tools = tool_registry.list_tools()
+    assert sample_tool_spec["name"] in tools
+    tool_info = tools[sample_tool_spec["name"]]
+    assert tool_info["versions"]["0.1.0"]["version"] == "0.1.0"
 
     # 3. Get the tool metadata
     metadata = tool_registry.get_tool_metadata(sample_tool_spec["name"])
@@ -200,16 +201,16 @@ async def test_tool_refinement_version_bump(
     assert orchestrator.tool_refined_total == 1
 
     # 3. Check version was bumped
-    tools_list = tool_registry.list_tools()
-    assert len(tools_list) == 1
-    tool_info = tools_list[0]
+    tools = tool_registry.list_tools()
+    assert sample_tool_spec["name"] in tools
+    tool_info = tools[sample_tool_spec["name"]]
     assert len(tool_info["versions"]) == 2
 
     # Versions should be sorted with newest first
     assert (
-        tool_info["versions"][0]["version"] == "0.2.0"
+        tool_info["versions"]["0.2.0"]["version"] == "0.2.0"
     )  # Minor bump for non-breaking change
-    assert tool_info["versions"][1]["version"] == "0.1.0"
+    assert tool_info["versions"]["0.1.0"]["version"] == "0.1.0"
 
     # 4. Load latest tool (should be v0.2.0)
     latest_tool = tool_registry.load(sample_tool_spec["name"], "latest")

--- a/tests/test_template_creator.py
+++ b/tests/test_template_creator.py
@@ -1,5 +1,6 @@
 from meta_agent.template_creator import TemplateCreator, validate_template
 from meta_agent.template_schema import (
+    IOContract,
     TemplateMetadata,
     TemplateCategory,
     TemplateComplexity,
@@ -13,7 +14,7 @@ def _meta() -> TemplateMetadata:
         title="Demo Template",
         description="Simple demo",
         intended_use="demo",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=[],
         guardrails=[],
         model_pref="gpt3",

--- a/tests/test_template_mixer.py
+++ b/tests/test_template_mixer.py
@@ -1,6 +1,7 @@
 from meta_agent.template_mixer import TemplateMixer
 from meta_agent.template_creator import TemplateCreator
 from meta_agent.template_schema import (
+    IOContract,
     TemplateMetadata,
     TemplateCategory,
     TemplateComplexity,
@@ -14,7 +15,7 @@ def _meta(slug: str) -> TemplateMetadata:
         title=slug,
         description="demo",
         intended_use="demo",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=[],
         guardrails=[],
         model_pref="gpt3",

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -1,5 +1,6 @@
 from meta_agent.template_registry import TemplateRegistry
 from meta_agent.template_schema import (
+    IOContract,
     TemplateMetadata,
     TemplateCategory,
     TemplateComplexity,
@@ -12,7 +13,7 @@ def _meta() -> TemplateMetadata:
         title="Greeting",
         description="Say hi",
         intended_use="demo",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=[],
         guardrails=[],
         model_pref="gpt3",

--- a/tests/test_template_schema.py
+++ b/tests/test_template_schema.py
@@ -1,6 +1,7 @@
 from pydantic import ValidationError
 
 from meta_agent.template_schema import (
+    IOContract,
     TemplateCategory,
     TemplateComplexity,
     TemplateMetadata,
@@ -13,7 +14,7 @@ def test_template_metadata_valid() -> None:
         title="Basic Chat Bot",
         description="Minimal conversational agent",
         intended_use="demo",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=[],
         guardrails=[],
         model_pref="gpt3",
@@ -38,7 +39,7 @@ def test_template_metadata_invalid_category() -> None:
             title="Bad",
             description="Bad",
             intended_use="demo",
-            io_contract={"input": "", "output": ""},
+            io_contract=IOContract(input="", output=""),
             tools=[],
             guardrails=[],
             model_pref="gpt3",
@@ -61,7 +62,7 @@ def test_template_metadata_compat_flags() -> None:
         title="Compat",
         description="desc",
         intended_use="demo",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=[],
         guardrails=[],
         model_pref="gpt3",

--- a/tests/test_template_search.py
+++ b/tests/test_template_search.py
@@ -1,5 +1,6 @@
 from meta_agent.template_registry import TemplateRegistry
 from meta_agent.template_schema import (
+    IOContract,
     TemplateMetadata,
     TemplateCategory,
     TemplateComplexity,
@@ -13,7 +14,7 @@ def _meta(slug: str, category: TemplateCategory) -> TemplateMetadata:
         title=slug.title(),
         description=f"Template {slug}",
         intended_use="demo",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=[],
         guardrails=[],
         model_pref="gpt3",

--- a/tests/test_template_sharing.py
+++ b/tests/test_template_sharing.py
@@ -1,5 +1,6 @@
 from meta_agent.template_sharing import TemplateSharingManager
 from meta_agent.template_schema import (
+    IOContract,
     TemplateMetadata,
     TemplateCategory,
     TemplateComplexity,
@@ -13,7 +14,7 @@ def _meta(slug: str) -> TemplateMetadata:
         title=slug,
         description="demo",
         intended_use="demo",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=[],
         guardrails=[],
         model_pref="gpt3",

--- a/tests/test_template_validator.py
+++ b/tests/test_template_validator.py
@@ -1,5 +1,6 @@
 from meta_agent.template_validator import TemplateValidator, TemplateTestCase
 from meta_agent.template_schema import (
+    IOContract,
     TemplateMetadata,
     TemplateCategory,
     TemplateComplexity,
@@ -55,7 +56,7 @@ def test_template_validator_license_scan(monkeypatch) -> None:
         title="Demo",
         description="",
         intended_use="",
-        io_contract={"input": "text", "output": "text"},
+        io_contract=IOContract(input="text", output="text"),
         tools=["badpkg"],
         guardrails=[],
         model_pref="gpt3",


### PR DESCRIPTION
## Summary
- use `IOContract` objects when building `TemplateMetadata`
- verify AST subscript slice type in tool code generator tests
- index tool lifecycle registry results by tool name

## Testing
- `black --check tests/test_template_mixer.py tests/test_template_schema.py tests/test_template_registry.py tests/test_template_creator.py tests/test_template_search.py tests/test_template_validator.py tests/test_template_sharing.py tests/generators/test_tool_code_generator.py tests/integration/test_tool_lifecycle.py`
- `ruff check .`
- `mypy src/meta_agent tests` *(fails: Missing imports and other errors)*
- `pyright` *(fails: numerous type errors)*
- `pytest -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6847071bdf48832fa47f3f0574ba6b8e