### PR TITLE
feat: alias base agent and add hosted tool stubs

### DIFF
--- a/src/meta_agent/agents/guardrail_designer_agent.py
+++ b/src/meta_agent/agents/guardrail_designer_agent.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, Optional
 
 
 try:
-    from agents import Agent
+    from agents import Agent as _Agent
 except Exception:  # pragma: no cover - fallback for missing SDK
 
-    class Agent:
+    class _Agent:
         """Minimal stand-in when the Agents SDK is unavailable."""
 
         def __init__(
@@ -26,10 +26,12 @@ except Exception:  # pragma: no cover - fallback for missing SDK
 from meta_agent.services.guardrail_router import GuardrailModelRouter, LLMModelAdapter
 from meta_agent.services.llm_service import LLMService
 
+BaseAgent = _Agent
+
 logger = logging.getLogger(__name__)
 
 
-class GuardrailDesignerAgent(Agent):
+class GuardrailDesignerAgent(BaseAgent):
     """Generates guardrail code using configurable model backends."""
 
     def __init__(

--- a/src/meta_agent/agents/tool_designer_agent.py
+++ b/src/meta_agent/agents/tool_designer_agent.py
@@ -17,16 +17,19 @@ TYPE_MAP = {
 
 # --- Import base Agent, handling potential unavailability ---
 try:
-    from agents import Agent
+    from agents import Agent as _Agent
 except ImportError:
     logging.warning("Failed to import 'Agent' from agents library. Using placeholder.")
 
-    class Agent:
-        def __init__(self, name=None, *args, **kwargs):
-            pass
+    class _Agent:
+        def __init__(self, name: str | None = None, *_: Any, **__: Any) -> None:
+            self.name = name or "StubAgent"
 
-        async def run(self, *args, **kwargs):
+        async def run(self, *_a: Any, **_kw: Any) -> Dict[str, Any]:
             return {"error": "Base Agent class not available"}
+
+
+BaseAgent = _Agent
 
 
 from meta_agent.parsers.tool_spec_parser import (
@@ -52,7 +55,7 @@ from meta_agent.generators.test_generator import generate_basic_tests
 logger = logging.getLogger(__name__)
 
 
-class ToolDesignerAgent(Agent):  # Inherit from Agent
+class ToolDesignerAgent(BaseAgent):
     """Orchestrates the process of parsing a tool specification and generating code."""
 
     def __init__(

--- a/src/meta_agent/sub_agent_manager.py
+++ b/src/meta_agent/sub_agent_manager.py
@@ -16,22 +16,23 @@ except (ImportError, AttributeError):
     logging.warning("Hosted tools unavailable: patching stubs into 'agents' package.")
 
     import agents as _agents_pkg  # type: ignore
+    from typing import Any
 
-    class _StubHostedTool:  # pylint: disable=too-few-public-methods
-        """Minimal stand‑in when WebSearchTool / FileSearchTool aren't shipped.
+    class WebSearchTool:  # type: ignore
+        """Typed fallback when the real hosted tool is missing."""
 
-        `Tool()` → returns instance; instance is **callable** so that
-        `WebSearchTool()(query)` works without raising TypeError.
-        """
+        def __call__(self, query: str, *args: Any, **kwargs: Any) -> str:
+            return "Hosted tool unavailable in this environment."
 
-        def __call__(self, *_, **__):  # noqa: D401,E501
+    class FileSearchTool:  # type: ignore
+        """Typed fallback when the real hosted tool is missing."""
+
+        def __call__(self, query: str, *args: Any, **kwargs: Any) -> str:
             return "Hosted tool unavailable in this environment."
 
     # expose the stubs both locally *and* inside the real `agents` module
-    WebSearchTool = _StubHostedTool()  # type: ignore
-    FileSearchTool = _StubHostedTool()  # type: ignore
-    _agents_pkg.WebSearchTool = WebSearchTool  # type: ignore
-    _agents_pkg.FileSearchTool = FileSearchTool  # type: ignore
+    _agents_pkg.WebSearchTool = WebSearchTool
+    _agents_pkg.FileSearchTool = FileSearchTool
     from agents import Agent
 
 from meta_agent.models.generated_tool import GeneratedTool
@@ -39,12 +40,6 @@ from meta_agent.generators.code_validator import CodeValidator
 import time
 
 logger = logging.getLogger(__name__)
-
-# --- Imports for Agent Logic ---
-from agents import Agent
-
-# --- Logging Setup ---
-import logging
 
 # --- Placeholder Sub-Agent Classes --- #
 


### PR DESCRIPTION
## Summary
- alias `Agent` import to `BaseAgent` for tool and guardrail designer agents
- inherit from `BaseAgent` in designer agents
- stub `WebSearchTool` and `FileSearchTool` with typed fallbacks

## Testing
- `ruff check src/meta_agent/agents/guardrail_designer_agent.py src/meta_agent/agents/tool_designer_agent.py src/meta_agent/sub_agent_manager.py`
- `black --check src/meta_agent/agents/guardrail_designer_agent.py src/meta_agent/agents/tool_designer_agent.py src/meta_agent/sub_agent_manager.py`
- `mypy src/meta_agent/agents/guardrail_designer_agent.py src/meta_agent/agents/tool_designer_agent.py src/meta_agent/sub_agent_manager.py` *(fails: Name "BaseAgent" already defined, etc.)*
- `pyright` *(fails with 88 errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684736170c28832fbff742b5d3f01995