### PR TITLE
refactor: fallback types for api

### DIFF
--- a/src/meta_agent/api.py
+++ b/src/meta_agent/api.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, cast
 from datetime import datetime
 
 try:
     from fastapi import FastAPI, Query, HTTPException
     from pydantic import BaseModel
-except ImportError:
-    # Graceful fallback if FastAPI is not available
-    FastAPI = None
-    Query = None
-    HTTPException = None
-    BaseModel = object
+except ImportError:  # pragma: no cover - optional dependency missing
+    # Graceful fallback types when FastAPI or Pydantic are absent.
+    FastAPI = cast(Any, None)
+    Query = cast(Any, None)
+    HTTPException = cast(Any, None)
+    BaseModel = cast(Any, object)
 
 from .template_registry import TemplateRegistry
 from .template_search import TemplateSearchEngine
@@ -170,10 +170,11 @@ def create_app() -> FastAPI:
     return app
 
 
-# Global app instance for easy import
+# Global app instance for easy import by the CLI and tests.
 app = None
 try:
     app = create_app()
 except ImportError:
-    # FastAPI not available, app will be None
+    # FastAPI isn't installed; keep ``app`` as ``None`` so other
+    # parts of the codebase can handle the missing dependency gracefully.
     pass


### PR DESCRIPTION
## Summary
- fallback to `Any` types when FastAPI or Pydantic are missing
- clarify global `app` fallback comments

## Testing
- `ruff check src/meta_agent/api.py`
- `black --check src/meta_agent/api.py` *(fails: would reformat)*
- `pytest -v tests`
- `mypy src/meta_agent/api.py` *(fails: found errors)*
- `pyright src/meta_agent/api.py` *(fails: found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68473619b594832fa156da063cee328c