### PR TITLE
fix: improve template utilities

### DIFF
--- a/src/meta_agent/generators/tool_code_generator.py
+++ b/src/meta_agent/generators/tool_code_generator.py
@@ -2,7 +2,7 @@ import ast
 import logging
 import re
 from pathlib import Path
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, Template
 from meta_agent.parsers.tool_spec_parser import ToolSpecification
 
 TYPE_MAP = {
@@ -14,6 +14,7 @@ TYPE_MAP = {
     "dict": "Dict",
     "any": "Any",
 }
+
 
 def map_type(spec_type: str) -> str:
     """Recursively map specification type string to Python type hint string."""
@@ -28,13 +29,16 @@ def map_type(spec_type: str) -> str:
         return f"{base_py}[{', '.join(inner_types)}]"
     return TYPE_MAP.get(spec_type.lower(), "Any")
 
+
 class CodeGenerationError(Exception):
     pass
 
+
 class ToolCodeGenerator:
     """Generates Python code for a tool based on its specification."""
-    _env = None
-    _template = None
+
+    _env: Environment | None = None
+    _template: Template | None = None
 
     def __init__(self, specification: ToolSpecification):
         self.specification = specification
@@ -45,9 +49,11 @@ class ToolCodeGenerator:
                 trim_blocks=True,
                 lstrip_blocks=True,
             )
-            ToolCodeGenerator._env.globals['map_type'] = map_type
+            ToolCodeGenerator._env.globals["map_type"] = map_type
         if not ToolCodeGenerator._template:
-            ToolCodeGenerator._template = ToolCodeGenerator._env.get_template("tool_template.py.j2")
+            ToolCodeGenerator._template = ToolCodeGenerator._env.get_template(
+                "tool_template.py.j2"
+            )
 
     def generate(self) -> str:
         try:
@@ -56,7 +62,9 @@ class ToolCodeGenerator:
                 ast.parse(generated_code)
             except SyntaxError as se:
                 logging.error(f"Syntax error in generated code: {se}")
-                raise CodeGenerationError(f"Syntax error in generated code: {se}\n\n{generated_code}")
+                raise CodeGenerationError(
+                    f"Syntax error in generated code: {se}\n\n{generated_code}"
+                )
             return generated_code
         except Exception as e:
             logging.exception("Error during code generation")

--- a/src/meta_agent/template_engine.py
+++ b/src/meta_agent/template_engine.py
@@ -1,19 +1,23 @@
-from typing import Dict, Any, Tuple
+from typing import Any, Dict, Tuple
 from jinja2 import Environment, FileSystemLoader, Template
 import os
 import ast
+
 
 class TemplateEngine:
     """
     Combines sub-agent outputs into a final agent implementation using Jinja2 templates.
     """
-    def __init__(self, templates_dir: str = None):
+
+    def __init__(self, templates_dir: str | None = None):
         if templates_dir is None:
             templates_dir = os.path.join(os.path.dirname(__file__), "templates")
         self.env = Environment(loader=FileSystemLoader(templates_dir))
         self.default_template_name = "agent_default.j2"
 
-    def assemble_agent(self, sub_agent_outputs: Dict[str, Any], template_name: str = None) -> str:
+    def assemble_agent(
+        self, sub_agent_outputs: Dict[str, Any], template_name: str = None
+    ) -> str:
         """
         Combine sub-agent outputs using the specified template.
         sub_agent_outputs: dict with keys like 'tools', 'guardrails', 'core_logic', etc.

--- a/src/meta_agent/template_mixer.py
+++ b/src/meta_agent/template_mixer.py
@@ -38,7 +38,8 @@ class TemplateMixer:
 
     def __init__(self, registry: Optional[TemplateRegistry] = None) -> None:
         self.registry = registry or TemplateRegistry()
-        self.env = Environment(loader=_RegistryLoader(self.registry))
+        loader: BaseLoader = _RegistryLoader(self.registry)
+        self.env = Environment(loader=loader)
 
     def render(
         self,

--- a/src/meta_agent/template_registry.py
+++ b/src/meta_agent/template_registry.py
@@ -63,11 +63,7 @@ class TemplateRegistry:
         template_path = version_dir / TEMPLATE_FILE_NAME
         template_path.write_text(content, encoding="utf-8")
         checksum = sha256(content.encode("utf-8")).hexdigest()
-        metadata_dict = (
-            metadata.model_dump()
-            if hasattr(metadata, "model_dump")
-            else metadata.dict()
-        )
+        metadata_dict = getattr(metadata, "model_dump", metadata.dict)()
         meta_data = {
             **metadata_dict,
             "version": version,

--- a/src/meta_agent/template_sharing.py
+++ b/src/meta_agent/template_sharing.py
@@ -7,7 +7,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from .template_registry import TemplateRegistry, METADATA_FILE_NAME
 from .template_creator import TemplateCreator
-from .template_schema import TemplateMetadata
+from .template_schema import (
+    TemplateCategory,
+    TemplateComplexity,
+    TemplateMetadata,
+)
 
 
 class TemplateSharingManager:
@@ -70,9 +74,17 @@ class TemplateSharingManager:
             tools=meta.get("tools", []),
             guardrails=meta.get("guardrails", []),
             model_pref=meta.get("model_pref", ""),
-            category=meta.get("category"),
+            category=(
+                TemplateCategory(meta.get("category"))
+                if meta.get("category")
+                else TemplateCategory.CONVERSATION
+            ),
             subcategory=meta.get("subcategory"),
-            complexity=meta.get("complexity"),
+            complexity=(
+                TemplateComplexity(meta.get("complexity"))
+                if meta.get("complexity")
+                else TemplateComplexity.BASIC
+            ),
             created_by=meta.get("created_by", "unknown"),
             semver=meta.get("semver", "0.0.0"),
             last_test_passed=meta.get("last_test_passed"),


### PR DESCRIPTION
## Summary
- allow optional template directory for TemplateEngine
- annotate ToolCodeGenerator's class-level Jinja objects
- use BaseLoader when instantiating TemplateMixer
- coerce imported template metadata to enums
- handle model_dump access gracefully in TemplateRegistry

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat 50 files)*
- `mypy .` *(fails: duplicate module error)*
- `pyright` *(fails: 82 errors, 4 warnings)*
- `pytest -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6847361c59c4832f8d063ef6f606984f