### PR TITLE
fix: guard tool file writes

### DIFF
--- a/src/meta_agent/validation.py
+++ b/src/meta_agent/validation.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 def validate_generated_tool(
-    tool: GeneratedTool, tool_id: str = None
+    tool: GeneratedTool, tool_id: str | None = None
 ) -> ValidationResult:
     """
     Run pytest and coverage on the generated tool code and tests.
@@ -35,8 +35,9 @@ def validate_generated_tool(
 
     with open(code_file, "w") as f:
         f.write(tool.code)
-    with open(test_file, "w") as f:
-        f.write(tool.tests)
+    if tool.tests:
+        with open(test_file, "w") as f:
+            f.write(tool.tests)
     # Write docs if present
     if tool.docs:
         with open(os.path.join(artefact_dir, "docs.md"), "w") as f:


### PR DESCRIPTION
## Summary
- avoid writing tests/docs when not provided
- annotate optional `tool_id`

## Testing
- `ruff check .`
- `black --check src/meta_agent/validation.py`
- `mypy src/meta_agent` *(fails: Incompatible default for argument "templates_dir")*
- `pyright` *(fails: 84 errors)*
- `pytest -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6847361f5a5c832f89cde34fb08af6c7