### PR TITLE
feat: add typed telemetry row and model_dump

### DIFF
--- a/src/meta_agent/cli/main.py
+++ b/src/meta_agent/cli/main.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 try:
     from dotenv import load_dotenv
 except Exception:  # pragma: no cover - fallback when python-dotenv is missing
 
-    def load_dotenv(*_args, **_kwargs) -> None:
+    def load_dotenv(*_args: Any, **_kwargs: Any) -> None:
         return None
 
 
@@ -23,7 +25,7 @@ from meta_agent.sub_agent_manager import SubAgentManager
 from meta_agent.registry import ToolRegistry
 from meta_agent.tool_designer import ToolDesignerAgent
 from meta_agent.telemetry import TelemetryCollector
-from meta_agent.telemetry_db import TelemetryDB
+from meta_agent.telemetry_db import TelemetryDB, TelemetryRow
 from meta_agent.template_registry import TemplateRegistry
 from meta_agent.template_search import TemplateSearchEngine
 from meta_agent.template_docs_generator import TemplateDocsGenerator
@@ -342,7 +344,7 @@ def tool_command_wrapper(action, spec_file, use_llm, version):
 def dashboard(db_path: Path) -> None:
     """Display a simple telemetry dashboard."""
     db = TelemetryDB(db_path)
-    records = db.fetch_all()
+    records: list[TelemetryRow] = db.fetch_all()
     if not records:
         click.echo("No telemetry data found.")
         db.close()

--- a/src/meta_agent/models/spec_schema.py
+++ b/src/meta_agent/models/spec_schema.py
@@ -8,11 +8,25 @@ try:
     from pydantic import field_validator
 except ImportError:  # Pydantic v1
     from pydantic import validator as field_validator
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Protocol
+
+    class _ModelDumpProtocol(Protocol):
+        def model_dump(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+            ...
 
 
 class SpecSchema(BaseModel):
     """Data model for agent specifications."""
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Return model data as a dictionary across Pydantic versions."""
+        base = getattr(super(), "model_dump", None)
+        if callable(base):
+            return base(*args, **kwargs)
+        return self.dict(*args, **kwargs)
 
     task_description: str = Field(
         ..., description="Detailed description of the agent's task and requirements."

--- a/src/meta_agent/telemetry_db.py
+++ b/src/meta_agent/telemetry_db.py
@@ -4,7 +4,17 @@ import csv
 import gzip
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Dict, Optional, Iterable
+from typing import List, Optional, Iterable, TypedDict
+
+
+class TelemetryRow(TypedDict):
+    """Typed representation of a telemetry record."""
+
+    timestamp: str
+    tokens: int
+    cost: float
+    latency: float
+    guardrail_hits: int
 
 
 class TelemetryDB:
@@ -59,7 +69,7 @@ class TelemetryDB:
         self,
         start: datetime | str | None = None,
         end: datetime | str | None = None,
-    ) -> List[Dict[str, object]]:
+    ) -> List[TelemetryRow]:
         """Fetch records optionally filtered by ``start``/``end`` timestamps."""
         conds: List[str] = []
         params: List[str] = []
@@ -98,7 +108,7 @@ class TelemetryDB:
         start: datetime | str | None = None,
         end: datetime | str | None = None,
         metrics: Iterable[str] | None = None,
-    ) -> List[Dict[str, object]]:
+    ) -> List[TelemetryRow]:
         data = self._query(start=start, end=end)
         if metrics is not None:
             allowed = set(metrics)


### PR DESCRIPTION
## Summary
- ensure fallback `load_dotenv` stub returns `None`
- define a `model_dump` helper in `SpecSchema`
- introduce `TelemetryRow` typed dict and use it in CLI

## Testing
- `ruff check .`
- `black --check .` *(fails)*
- `mypy src/meta_agent tests` *(fails)*
- `pyright src/meta_agent tests` *(fails: KeyboardInterrupt)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684736201f90832fb56080888ccd0df0