### PR TITLE
fix: address typing issues in tests

### DIFF
--- a/tests/generators/test_test_generator.py
+++ b/tests/generators/test_test_generator.py
@@ -7,7 +7,7 @@ def test_generate_basic_tests():
     spec = ToolSpecification(
         name="greet",
         purpose="Greets a user",
-        input_parameters=[ToolParameter(name="name", type_="string")],
+        input_parameters=[ToolParameter(name="name", type="string")],
         output_format="string",
     )
     test_code = generate_basic_tests(spec)

--- a/tests/integration/test_orchestration_e2e.py
+++ b/tests/integration/test_orchestration_e2e.py
@@ -1,8 +1,10 @@
 import os
+from typing import Any, Dict
 import pytest
 from meta_agent.state_manager import StateManager
 from meta_agent.template_engine import TemplateEngine, validate_agent_code
 from meta_agent.sub_agent_manager import CoderAgent, TesterAgent
+
 
 # Simulate a full orchestration run
 @pytest.mark.integration
@@ -16,19 +18,25 @@ def test_full_orchestration_e2e():
     spec = {"task_id": "foo", "description": "Write and test a function"}
     coder = CoderAgent()
     tester = TesterAgent()
-    coder_output = pytest.run(coro=coder.run(spec)) if hasattr(pytest, 'run') else None
+    coder_output = pytest.run(coro=coder.run(spec)) if hasattr(pytest, "run") else None
     if coder_output is None:
         import asyncio
+
         coder_output = asyncio.run(coder.run(spec))
-    tester_output = pytest.run(coro=tester.run(spec)) if hasattr(pytest, 'run') else None
+    tester_output = (
+        pytest.run(coro=tester.run(spec)) if hasattr(pytest, "run") else None
+    )
     if tester_output is None:
         import asyncio
+
         tester_output = asyncio.run(tester.run(spec))
 
     sm.update_progress(0.5, current_step="sub_agents_done")
 
     # 3. Assemble agent
-    templates_dir = os.path.join(os.path.dirname(__file__), "../../src/meta_agent/templates")
+    templates_dir = os.path.join(
+        os.path.dirname(__file__), "../../src/meta_agent/templates"
+    )
     engine = TemplateEngine(templates_dir=templates_dir)
     sub_agent_outputs = {
         "agent_class_name": "OrchestratedAgent",
@@ -36,7 +44,7 @@ def test_full_orchestration_e2e():
         "instructions": "Do everything",
         "core_logic": f"# {coder_output['output']}\n# {tester_output['output']}\nreturn 'done'",
         "tools": ["def tool1(self): pass"],
-        "guardrails": ["def guardrail1(self): pass"]
+        "guardrails": ["def guardrail1(self): pass"],
     }
     code = engine.assemble_agent(sub_agent_outputs)
     sm.update_progress(0.9, current_step="assembly_done")
@@ -48,7 +56,7 @@ def test_full_orchestration_e2e():
     sm.update_progress(1.0, current_step="done")
 
     # 5. Check reporting and state
-    report = sm.get_report(as_dict=True)
+    report: Dict[str, Any] = sm.get_report(as_dict=True)
     assert report["status"] == "completed"
     assert report["progress"] == 1.0
     assert report["current_step"] == "done"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -11,6 +11,7 @@ import tempfile
 import shutil
 import json
 from pathlib import Path
+from typing import Any, Dict
 from unittest.mock import patch, MagicMock
 
 # Import all the components we need to test
@@ -39,18 +40,18 @@ class TestMetaAgentE2E:
     @pytest.fixture
     def mock_docker(self):
         """Mock Docker to avoid requiring Docker daemon."""
-        with patch('meta_agent.sandbox.sandbox_manager.docker') as mock_docker:
+        with patch("meta_agent.sandbox.sandbox_manager.docker") as mock_docker:
             # Mock the Docker client
             mock_client = MagicMock()
             mock_client.ping.return_value = None
             mock_docker.from_env.return_value = mock_client
-            
+
             # Mock container execution
             mock_container = MagicMock()
-            mock_container.wait.return_value = {'StatusCode': 0}
+            mock_container.wait.return_value = {"StatusCode": 0}
             mock_container.logs.return_value = b"Test execution successful"
             mock_client.containers.run.return_value = mock_container
-            
+
             yield mock_docker
 
     @pytest.fixture
@@ -58,30 +59,27 @@ class TestMetaAgentE2E:
         """A complete, realistic tool specification."""
         return {
             "task_description": "Create a weather fetching tool",
-            "inputs": {
-                "city": "string",
-                "country_code": "string"
-            },
+            "inputs": {"city": "string", "country_code": "string"},
             "outputs": {
                 "temperature": "float",
                 "description": "string",
-                "humidity": "integer"
+                "humidity": "integer",
             },
             "constraints": [
                 "Must handle API errors gracefully",
                 "Should cache results for 5 minutes",
-                "Must validate city names"
+                "Must validate city names",
             ],
             "technical_requirements": [
                 "Use requests library",
                 "Implement proper error handling",
-                "Add comprehensive logging"
+                "Add comprehensive logging",
             ],
             "metadata": {
                 "author": "test_suite",
                 "version": "1.0.0",
-                "test_id": "e2e_weather_tool"
-            }
+                "test_id": "e2e_weather_tool",
+            },
         }
 
     @pytest.fixture
@@ -95,31 +93,31 @@ class TestMetaAgentE2E:
                     "name": "city",
                     "type": "string",
                     "description": "Name of the city",
-                    "required": True
+                    "required": True,
                 },
                 {
                     "name": "country_code",
                     "type": "string",
                     "description": "ISO country code",
-                    "required": False
-                }
+                    "required": False,
+                },
             ],
-            "output_format": "dict"
+            "output_format": "dict",
         }
 
     @pytest.fixture
     def mock_llm_service(self):
         """Mock LLM service to return deterministic code."""
-        with patch('meta_agent.services.llm_service.LLMService') as mock_service_class:
+        with patch("meta_agent.services.llm_service.LLMService") as mock_service_class:
             mock_instance = MagicMock()
             mock_service_class.return_value = mock_instance
-            
+
             # Return valid Python code for tool generation
             async def mock_generate_code(prompt, context):
                 return '''
 import requests
 import json
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from datetime import datetime, timedelta
 import logging
 
@@ -205,7 +203,7 @@ def test_weather_fetcher():
     except ValueError:
         pass
 '''
-            
+
             mock_instance.generate_code.side_effect = mock_generate_code
             yield mock_instance
 
@@ -220,40 +218,42 @@ def test_weather_fetcher():
         tool_registry = ToolRegistry(base_dir=temp_workspace)
         tool_designer_agent = ToolDesignerAgent()
         state_manager = StateManager()
-        
+
         # Create orchestrator
         orchestrator = MetaAgentOrchestrator(
             planning_engine=planning_engine,
             sub_agent_manager=sub_agent_manager,
             tool_registry=tool_registry,
-            tool_designer_agent=tool_designer_agent
+            tool_designer_agent=tool_designer_agent,
         )
-        
+
         # Parse specification
         spec_schema = SpecSchema.from_dict(complete_tool_spec)
-        
+
         # Run orchestration
         state_manager.set_status("running")
         state_manager.update_progress(0.1, "Starting orchestration")
-        
+
         # Execute the orchestration
         results = await orchestrator.run(spec_schema.model_dump())
-        
+
         state_manager.update_progress(0.5, "Orchestration complete")
-        
+
         # Verify results
         assert isinstance(results, dict)
         assert len(results) > 0  # Should have executed at least one task
-        
+
         # Check that tools were registered
         registered_tools = tool_registry.list_tools()
-        assert len(registered_tools) >= 0  # May or may not have tools depending on the flow
-        
+        assert (
+            len(registered_tools) >= 0
+        )  # May or may not have tools depending on the flow
+
         state_manager.update_progress(1.0, "Test complete")
         state_manager.set_status("completed")
-        
+
         # Generate final report
-        report = state_manager.get_report(as_dict=True)
+        report: Dict[str, Any] = state_manager.get_report(as_dict=True)
         assert report["status"] == "completed"
         assert report["progress"] == 1.0
 
@@ -264,39 +264,42 @@ def test_weather_fetcher():
         """Test tool generation and validation in isolation."""
         # Create tool designer agent
         agent = ToolDesignerAgent()
-        
+
         # Generate tool
         result = await agent.run(tool_designer_spec)
-        
+
         assert result["status"] == "success"
         tool_data = result["output"]
-        
+
         # Validate generated tool
         from meta_agent.models.generated_tool import GeneratedTool
+
         tool = GeneratedTool(
             code=tool_data["code"],
             tests=tool_data.get("tests", ""),
-            docs=tool_data.get("docs", "")
+            docs=tool_data.get("docs", ""),
         )
-        
+
         # Run validation
         validation_result = validate_generated_tool(tool, tool_id="e2e_test")
-        
+
         # For this test, we expect validation to pass with our mock code
-        assert validation_result.coverage >= 0  # Coverage might be 0 without actual pytest run
+        assert (
+            validation_result.coverage >= 0
+        )  # Coverage might be 0 without actual pytest run
 
     def test_cli_integration(self, temp_workspace, complete_tool_spec, mock_docker):
         """Test the CLI interface end-to-end."""
         runner = CliRunner()
-        
+
         # Create spec file
         spec_file = temp_workspace / "test_spec.json"
-        with open(spec_file, 'w') as f:
+        with open(spec_file, "w") as f:
             json.dump(complete_tool_spec, f)
-        
+
         # Run CLI command
-        result = runner.invoke(cli, ['generate', '--spec-file', str(spec_file)])
-        
+        result = runner.invoke(cli, ["generate", "--spec-file", str(spec_file)])
+
         # Check output
         assert result.exit_code == 0
         assert "Specification parsed successfully" in result.output
@@ -307,40 +310,41 @@ def test_weather_fetcher():
     async def test_tool_registry_lifecycle(self, temp_workspace, mock_llm_service):
         """Test the complete tool lifecycle in the registry."""
         registry = ToolRegistry(base_dir=temp_workspace)
-        
+
         # Create a tool
         from meta_agent.models.generated_tool import GeneratedTool
+
         tool = GeneratedTool(
             code="def test_func(): return 'test'",
             tests="def test_test_func(): assert test_func() == 'test'",
-            docs="# Test Tool\nA simple test tool"
+            docs="# Test Tool\nA simple test tool",
         )
         tool.name = "test_tool"
         tool.description = "A test tool"
         tool.specification = {"test": "spec"}
-        
+
         # Register the tool
         module_path = registry.register(tool, version="0.1.0")
         assert module_path is not None
-        
+
         # List tools
         tools = registry.list_tools()
         assert len(tools) == 1
         assert tools[0]["name"] == "test_tool"
-        
+
         # Get metadata
         metadata = registry.get_tool_metadata("test_tool")
         assert metadata is not None
         assert metadata["description"] == "A test tool"
-        
+
         # Load the tool
         loaded_tool = registry.load("test_tool")
         assert loaded_tool is not None
-        
+
         # Unregister
         success = registry.unregister("test_tool")
         assert success
-        
+
         # Verify it's gone
         tools_after = registry.list_tools()
         assert len(tools_after) == 0
@@ -353,51 +357,53 @@ def test_weather_fetcher():
         # Test with invalid specification
         invalid_spec = complete_tool_spec.copy()
         del invalid_spec["task_description"]  # Remove required field
-        
+
         # Should raise validation error
         with pytest.raises(Exception) as exc_info:
             SpecSchema.from_dict(invalid_spec)
         assert "task_description" in str(exc_info.value)
-        
+
         # Test with LLM failure
-        with patch('meta_agent.services.llm_service.LLMService') as mock_service_class:
+        with patch("meta_agent.services.llm_service.LLMService") as mock_service_class:
             mock_instance = MagicMock()
             mock_service_class.return_value = mock_instance
-            
+
             # Make LLM raise an error
             async def mock_fail(*args, **kwargs):
                 raise Exception("LLM API Error")
-            
+
             mock_instance.generate_code.side_effect = mock_fail
-            
+
             agent = ToolDesignerAgent()
-            result = await agent.run({
-                "name": "failing_tool",
-                "purpose": "This will fail",
-                "input_parameters": [],
-                "output_format": "string"
-            })
-            
+            result = await agent.run(
+                {
+                    "name": "failing_tool",
+                    "purpose": "This will fail",
+                    "input_parameters": [],
+                    "output_format": "string",
+                }
+            )
+
             # Should handle the error gracefully
             assert result["status"] in ["success", "error"]  # Depends on error handling
 
     def test_state_persistence_and_recovery(self, temp_workspace):
         """Test state persistence across restarts."""
         state_file = temp_workspace / "state.json"
-        
+
         # Create initial state
         sm1 = StateManager()
         sm1.update_progress(0.5, "halfway")
         sm1.set_status("running")
         sm1.register_failure("task1")
-        
+
         # Save state
         assert sm1.save_state(str(state_file))
-        
+
         # Load in new instance
         sm2 = StateManager()
         assert sm2.load_state(str(state_file))
-        
+
         # Verify state was preserved
         assert sm2.get_progress() == 0.5
         assert sm2.get_status() == "running"
@@ -407,7 +413,7 @@ def test_weather_fetcher():
     async def test_concurrent_tool_generation(self, temp_workspace, mock_llm_service):
         """Test generating multiple tools concurrently."""
         agent = ToolDesignerAgent()
-        
+
         # Create multiple tool specs
         specs = [
             {
@@ -416,15 +422,15 @@ def test_weather_fetcher():
                 "input_parameters": [
                     {"name": "input", "type": "string", "required": True}
                 ],
-                "output_format": "string"
+                "output_format": "string",
             }
             for i in range(3)
         ]
-        
+
         # Generate tools concurrently
         tasks = [agent.run(spec) for spec in specs]
         results = await asyncio.gather(*tasks)
-        
+
         # Verify all succeeded
         for i, result in enumerate(results):
             assert result["status"] == "success"

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,4 +1,6 @@
 from meta_agent.state_manager import StateManager
+from typing import Any, Dict
+
 
 def test_progress_and_status():
     sm = StateManager()
@@ -11,6 +13,7 @@ def test_progress_and_status():
     assert state["current_step"] == "step1"
     assert "step1" in state["steps"]
 
+
 def test_persistence(tmp_path):
     sm = StateManager()
     sm.update_progress(0.7, current_step="foo")
@@ -21,6 +24,7 @@ def test_persistence(tmp_path):
     assert sm2.get_progress() == 0.7
     assert sm2.get_state()["current_step"] == "foo"
 
+
 def test_checkpoint(tmp_path):
     sm = StateManager()
     sm.update_progress(0.2, current_step="bar")
@@ -29,6 +33,7 @@ def test_checkpoint(tmp_path):
     sm.restore_checkpoint("cp1", directory=str(tmp_path))
     assert sm.get_progress() == 0.2
     assert sm.get_state()["current_step"] == "bar"
+
 
 def test_retry_logic():
     sm = StateManager()
@@ -44,13 +49,14 @@ def test_retry_logic():
     sm.reset_retries()
     assert sm.should_retry(step, max_retries=3)
 
+
 def test_reporting():
     sm = StateManager()
     sm.update_progress(1.0, current_step="done")
     sm.set_status("completed")
     sm.register_failure("foo")
     report_str = sm.get_report()
-    report_dict = sm.get_report(as_dict=True)
+    report_dict: Dict[str, Any] = sm.get_report(as_dict=True)
     assert isinstance(report_str, str)
     assert isinstance(report_dict, dict)
     assert report_dict["status"] == "completed"

--- a/tests/unit/test_sub_agent_manager.py
+++ b/tests/unit/test_sub_agent_manager.py
@@ -1,5 +1,6 @@
 # tests/unit/test_sub_agent_manager.py
 import pytest
+from typing import Any, Dict
 from unittest.mock import MagicMock, AsyncMock, patch
 
 # --- Import Actual Classes ---
@@ -368,7 +369,7 @@ def web_search(query: str) -> list:
 
     agent = ToolDesignerAgent()
     # Proper specification format
-    spec_search = {
+    spec_search: Dict[str, Any] = {
         "name": "WebSearchTool",
         "purpose": "Search the web for documentation",
         "output_format": "list",
@@ -390,7 +391,7 @@ async def test_tool_designer_generate_tool_filesearch():
     """Test ToolDesignerAgent.design_tool_with_llm for FileSearchTool."""
     agent = ToolDesignerAgent()
     # Proper specification format
-    spec_filesearch = {
+    spec_filesearch: Dict[str, Any] = {
         "name": "FileSearchTool",
         "purpose": "Search files using embeddings",
         "output_format": "list",
@@ -411,7 +412,7 @@ async def test_tool_designer_generate_tool_filesearch():
 async def test_tool_designer_generate_tool_openweathermap():
     """Test ToolDesignerAgent.generate_tool for OpenWeatherMap trigger keywords."""
     agent = ToolDesignerAgent()
-    spec_weather = {
+    spec_weather: Dict[str, Any] = {
         "name": "WeatherTool",
         "purpose": "Get weather data",
         "output_format": "dict",


### PR DESCRIPTION
## Summary
- use alias parameter name `type` in generator tests
- verify AST node types before checking attributes
- annotate StateManager report dicts in integration tests
- declare spec dictionaries as typed in sub agent tests

## Testing
- `black --check tests/generators/test_test_generator.py tests/generators/test_tool_code_generator.py tests/integration/test_orchestration_e2e.py tests/test_e2e.py tests/test_state_manager.py tests/unit/test_sub_agent_manager.py`
- `ruff check tests/generators/test_test_generator.py tests/generators/test_tool_code_generator.py tests/integration/test_orchestration_e2e.py tests/test_e2e.py tests/test_state_manager.py tests/unit/test_sub_agent_manager.py`
- `mypy src/meta_agent tests --explicit-package-bases` *(fails: Cannot find implementation or library stubs)*
- `pyright` *(fails: multiple type errors)*
- `pytest -v --cov=src/meta_agent tests` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_684736231b90832f95c5ad23e531bb58