### PR TITLE
feat: allow sequence in benchmark

### DIFF
--- a/src/meta_agent/embedding_benchmark.py
+++ b/src/meta_agent/embedding_benchmark.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from .embedding_models import (
     EmbeddingModel,
@@ -106,7 +106,7 @@ class TemplateBenchmarkRunner:
 
     def run_benchmark(
         self,
-        models: Optional[List[EmbeddingModel]] = None,
+        models: Sequence[EmbeddingModel] | None = None,
         save_results: bool = True,
     ) -> List[EmbeddingMetrics]:
         """Run the complete benchmark suite."""

--- a/src/meta_agent/embedding_models.py
+++ b/src/meta_agent/embedding_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 
 def _hash_embed(text: str, dim: int) -> List[float]:
@@ -221,10 +221,12 @@ class EmbeddingModelBenchmark:
 
         return dot_product / (norm1 * norm2)
 
-    def run_benchmark(self, models: List[EmbeddingModel]) -> List[EmbeddingMetrics]:
+    def run_benchmark(
+        self, models: Sequence[EmbeddingModel] | None = None
+    ) -> List[EmbeddingMetrics]:
         """Run benchmark on all provided models."""
-        results = []
-        for model in models:
+        results: List[EmbeddingMetrics] = []
+        for model in models or []:
             metrics = self.benchmark_model(model)
             results.append(metrics)
         return results


### PR DESCRIPTION
## Summary
- support Sequence for `run_benchmark`
- keep TemplateBenchmarkRunner compatible with lists

## Testing
- `ruff check src/meta_agent/embedding_models.py src/meta_agent/embedding_benchmark.py`
- `black --check src/meta_agent/embedding_models.py src/meta_agent/embedding_benchmark.py`
- `mypy src/meta_agent/embedding_models.py src/meta_agent/embedding_benchmark.py` *(fails: Argument "loader" to "Environment" has incompatible type "_RegistryLoader")*
- `pyright src/meta_agent/embedding_models.py src/meta_agent/embedding_benchmark.py`
- `pytest tests/test_embedding_models.py tests/test_embedding_benchmark.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68473623de00832fa3ce067624fa57f7