### PR TITLE
ci: force pydantic version

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --extra test
+          # ensure compatible pydantic version for openai
+          uv pip install 'pydantic>=2.10,<3'
       - name: Run test suite
         env:
           # Ensure OpenAI API key is not required for tests (they should be mocked)


### PR DESCRIPTION
## Summary
- enforce a minimum pydantic version when installing dependencies in CI

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `mypy .` *(fails: duplicate module named "meta_agent")*
- `pyright`
- `pytest -q` *(fails: TypeError in openai during import)*

------
https://chatgpt.com/codex/tasks/task_e_684f1bf70028832f98a8f30830798178