### PR TITLE
week1: wire BullMQ + Redis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,6 @@ AGENTS quickstart (v2-rewrite current, v1-lts maintained)
 - Keep this file updated as v2 scaffolding lands; PRs are required on v1-lts (branch protection enabled).
 - Docs lookup (Mastra): When you need technical details about the Mastra framework, use the Mastra MCP Docs Server to retrieve them via the MCP (functions.mcp__mastra__mastraDocs). Prefer this over web search for Mastra-specific APIs and guides.
 - When making changes, follow the [feature PR checklist](docs/checklists.md#feature-pr-checklist) and make sure to check off each item.
+- Always create feedback loops like tests to validate your changes.
+- Ensure that your changes are compatible with the existing codebase and do not introduce breaking changes.
+- Keep this file updated as v2 scaffolding lands; PRs are required on v1-lts (branch protection enabled).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "packageManager": "pnpm@8.12.1",
   "scripts": {
-    "dev": "turbo run dev --parallel",
+    "dev": "pnpm db:up && turbo run dev --parallel",
     "build": "turbo run build",
     "typecheck": "turbo run build",
     "lint": "turbo run lint",

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@metaagent/queue",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "echo \"[dev] @metaagent/queue – no dev server\"",
+    "build": "tsc -p .",
+    "lint": "echo \"[lint] @metaagent/queue – implement later\"",
+    "test": "pnpm run build && node tests/queue.integration.mjs"
+  },
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "bullmq": "^5.41.0",
+    "ioredis": "^5.4.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./redis.js";
+export * from "./queues.js";

--- a/packages/queue/src/queues.ts
+++ b/packages/queue/src/queues.ts
@@ -1,0 +1,33 @@
+import { Queue, Worker, type JobsOptions } from "bullmq";
+import { redisOptions } from "./redis.js";
+import type { AgentExecData, AgentExecResult } from "./types.js";
+
+export const AGENT_EXEC_QUEUE = "agent-exec";
+
+export const agentExecQueue = new Queue<AgentExecData>(AGENT_EXEC_QUEUE, {
+  connection: redisOptions,
+});
+
+export function enqueueAgentExec(
+  data: AgentExecData,
+  opts?: JobsOptions
+) {
+  return agentExecQueue.add("run", data, {
+    removeOnComplete: 100,
+    attempts: 3,
+    backoff: { type: "exponential", delay: 5000 },
+    ...opts,
+  });
+}
+
+export function createAgentExecWorker(
+  handler: (data: AgentExecData) => Promise<AgentExecResult>,
+  opts?: { concurrency?: number }
+) {
+  const worker = new Worker<AgentExecData>(
+    AGENT_EXEC_QUEUE,
+    async (job) => handler(job.data),
+    { connection: redisOptions, concurrency: opts?.concurrency ?? 5 }
+  );
+  return worker;
+}

--- a/packages/queue/src/redis.ts
+++ b/packages/queue/src/redis.ts
@@ -1,0 +1,18 @@
+import type { RedisOptions } from "ioredis";
+
+function fromEnv(): RedisOptions {
+  const urlStr = process.env.REDIS_URL ?? "redis://localhost:6379";
+  const u = new URL(urlStr);
+  const password = u.password || undefined;
+  const host = u.hostname || "localhost";
+  const port = u.port ? Number(u.port) : 6379;
+  return {
+    host,
+    port,
+    password,
+    maxRetriesPerRequest: null,
+    enableReadyCheck: true,
+  } as RedisOptions;
+}
+
+export const redisOptions: RedisOptions = fromEnv();

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -1,0 +1,11 @@
+export interface AgentExecData {
+  runId: string;
+  prompt: string;
+  context?: unknown;
+}
+
+export interface AgentExecResult {
+  runId: string;
+  output: string;
+  logs?: string[];
+}

--- a/packages/queue/tests/queue.integration.mjs
+++ b/packages/queue/tests/queue.integration.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
+import Redis from 'ioredis';
+import { agentExecQueue, enqueueAgentExec, createAgentExecWorker, redisOptions } from '../dist/index.js';
+
+async function redisAvailable() {
+  const client = new Redis(redisOptions);
+  try {
+    const res = await client.ping();
+    return res === 'PONG';
+  } catch {
+    return false;
+  } finally {
+    client.disconnect();
+  }
+}
+
+async function main() {
+  if (!(await redisAvailable())) {
+    console.log('[queue.integration] SKIP: no Redis available');
+    process.exit(0);
+  }
+
+  const runId = `itest-${Date.now()}`;
+  let processed = null;
+
+  const worker = createAgentExecWorker(async (data) => {
+    processed = { ...data, output: `ok:${data.prompt}` };
+    return { runId: data.runId, output: processed.output };
+  }, { concurrency: 1 });
+
+  const timeoutMs = 5000;
+  const start = Date.now();
+
+  await enqueueAgentExec({ runId, prompt: 'ping' });
+
+  while (!processed && Date.now() - start < timeoutMs) {
+    await delay(50);
+  }
+
+  try {
+    assert.ok(processed, 'Job was not processed in time');
+    assert.equal(processed.runId, runId);
+    assert.equal(processed.output, 'ok:ping');
+    console.log('[queue.integration] PASS');
+  } finally {
+    await worker.close();
+    await agentExecQueue.drain();
+    await agentExecQueue.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('[queue.integration] FAIL', err);
+  process.exit(1);
+});

--- a/packages/queue/tsconfig.json
+++ b/packages/queue/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,19 @@ importers:
         specifier: ^5.3.3
         version: 5.9.2
 
+  packages/queue:
+    dependencies:
+      bullmq:
+        specifier: ^5.41.0
+        version: 5.58.5
+      ioredis:
+        specifier: ^5.4.1
+        version: 5.7.0
+    devDependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.2
+
   packages/spec:
     devDependencies:
       typescript:
@@ -146,6 +159,9 @@ importers:
 
   services/builder:
     dependencies:
+      '@metaagent/queue':
+        specifier: workspace:*
+        version: link:../../packages/queue
       '@metaagent/toolkit':
         specifier: workspace:*
         version: link:../../packages/toolkit
@@ -165,6 +181,9 @@ importers:
 
   services/runner:
     dependencies:
+      '@metaagent/queue':
+        specifier: workspace:*
+        version: link:../../packages/queue
       '@metaagent/toolkit':
         specifier: workspace:*
         version: link:../../packages/toolkit
@@ -1581,6 +1600,10 @@ packages:
     dependencies:
       fast-deep-equal: 3.1.3
 
+  /@ioredis/commands@1.3.1:
+    resolution: {integrity: sha512-bYtU8avhGIcje3IhvF9aSjsa5URMZBHnwKtOvXsT4sfYy9gppW11gLPT/9oNqlJZD47yPKveQFTAFWpHjKvUoQ==}
+    dev: false
+
   /@isaacs/cliui@8.0.2:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1657,6 +1680,54 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3:
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3:
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3:
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3:
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3:
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3:
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@npmcli/fs@3.1.1:
     resolution: {integrity: sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==}
@@ -2480,6 +2551,20 @@ packages:
       ieee754: 1.2.1
     dev: true
 
+  /bullmq@5.58.5:
+    resolution: {integrity: sha512-0A6Qjxdn8j7aOcxfRZY798vO/aMuwvoZwfE6a9EOXHb1pzpBVAogsc/OfRWeUf+5wMBoYB5nthstnJo/zrQOeQ==}
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.7.0
+      msgpackr: 1.11.5
+      node-abort-controller: 3.1.1
+      semver: 7.7.2
+      tslib: 2.8.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -2607,6 +2692,11 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
+  /cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2691,6 +2781,13 @@ packages:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
 
+  /cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      luxon: 3.7.2
+    dev: false
+
   /cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2743,7 +2840,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
 
   /decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -2783,6 +2879,11 @@ packages:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
+
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2795,6 +2896,13 @@ packages:
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  /detect-libc@2.0.4:
+    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -3698,6 +3806,23 @@ packages:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
     dev: true
 
+  /ioredis@5.7.0:
+    resolution: {integrity: sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.3.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.1
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -3947,6 +4072,14 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
 
+  /lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: false
+
+  /lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+    dev: false
+
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
@@ -3983,6 +4116,11 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
     dev: true
+
+  /luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+    dev: false
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -4549,6 +4687,28 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    dev: false
+    optional: true
+
+  /msgpackr@1.11.5:
+    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+    dev: false
+
   /nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4562,6 +4722,19 @@ packages:
   /negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
+
+  /node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+    dev: false
+
+  /node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      detect-libc: 2.0.4
+    dev: false
+    optional: true
 
   /node-releases@2.0.20:
     resolution: {integrity: sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==}
@@ -5228,6 +5401,18 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  /redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
+    dev: false
+
   /remark-frontmatter@4.0.1:
     resolution: {integrity: sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==}
     dependencies:
@@ -5564,6 +5749,10 @@ packages:
       minipass: 7.1.2
     dev: true
 
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
+
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -5776,6 +5965,10 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    dev: false
+
   /turbo-darwin-64@1.13.4:
     resolution: {integrity: sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==}
     cpu: [x64]
@@ -5974,6 +6167,11 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}

--- a/services/builder/package.json
+++ b/services/builder/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@metaagent/toolkit": "workspace:*",
+    "@metaagent/queue": "workspace:*",
     "dotenv": "^16.4.5",
     "fastify": "^4.28.1"
   },

--- a/services/builder/src/index.ts
+++ b/services/builder/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify";
 import dotenv from "dotenv";
 import { logger } from "@metaagent/toolkit";
+import { enqueueAgentExec } from "@metaagent/queue";
 
 dotenv.config();
 
@@ -8,6 +9,12 @@ const app = Fastify({ logger });
 
 app.get("/healthz", async () => ({ status: "ok" }));
 app.get("/readyz", async () => ({ status: "ready" }));
+
+app.post("/jobs/demo", async () => {
+  const runId = `demo-${Date.now()}`;
+  await enqueueAgentExec({ runId, prompt: "Hello from builder" });
+  return { enqueued: true, runId };
+});
 
 const port = Number(process.env.BUILDER_PORT ?? 3101);
 app.listen({ port, host: "0.0.0.0" }).catch((err) => {

--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@metaagent/toolkit": "workspace:*",
+    "@metaagent/queue": "workspace:*",
     "dotenv": "^16.4.5",
     "fastify": "^4.28.1"
   },

--- a/services/runner/src/index.ts
+++ b/services/runner/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify";
 import dotenv from "dotenv";
 import { logger } from "@metaagent/toolkit";
+import { createAgentExecWorker } from "@metaagent/queue";
 
 dotenv.config();
 
@@ -8,6 +9,22 @@ const app = Fastify({ logger });
 
 app.get("/healthz", async () => ({ status: "ok" }));
 app.get("/readyz", async () => ({ status: "ready" }));
+
+// Start BullMQ worker
+const worker = createAgentExecWorker(async (data) => {
+  app.log.info({ runId: data.runId, prompt: data.prompt }, "processing job");
+  // mock execution
+  const output = `echo: ${data.prompt}`;
+  return { runId: data.runId, output };
+});
+
+const shutdown = async () => {
+  await worker.close();
+  await app.close();
+  process.exit(0);
+};
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
 
 const port = Number(process.env.RUNNER_PORT ?? 3102);
 app.listen({ port, host: "0.0.0.0" }).catch((err) => {


### PR DESCRIPTION
- Add shared @metaagent/queue package (types, redis opts, enqueue/worker helpers)
- Integrate builder as producer (/jobs/demo) and runner as worker with graceful shutdown
- Infra: use existing redis in infra/docker-compose; dev script starts DB+Redis
- Add integration test for queue package (skips if no Redis), update scripts
- Fix .env.example and test orchestration

Amp-Thread-ID: https://ampcode.com/threads/T-b3e500b8-2841-44e6-81f5-45b8bc30329c