### PR TITLE
Builder flow: server-created draft + redirect to /builder/:id; autosa…

### DIFF
--- a/apps/web/app/routes/builder.$draftId.tsx
+++ b/apps/web/app/routes/builder.$draftId.tsx
@@ -1,4 +1,4 @@
-import { json, type LoaderFunctionArgs, type ActionFunctionArgs } from "@remix-run/node";
+import { json, redirect, type LoaderFunctionArgs, type ActionFunctionArgs } from "@remix-run/node";
 import { useLoaderData, useNavigate, useSearchParams } from "@remix-run/react";
 import { useState } from "react";
 import { createSpecDraftService } from "../utils/specDraft.server";
@@ -7,20 +7,22 @@ import InterviewPanel from "../components/InterviewPanel";
 import SpecPanel from "../components/SpecPanel";
 import { templates } from "@metaagent/templates";
 import { genericAgentInterview } from "@metaagent/interview";
-import { createDraftSpec } from "@metaagent/spec";
 
 function getUserId() { return "01ARZ3NDEKTSV4RRFFQ69G5FAV"; }
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const userId = getUserId();
   const service = createSpecDraftService(userId);
-  const url = new URL(request.url);
   const draftId = params.draftId;
 
-  let draft = draftId ? await service.getDraft(draftId) : null;
+  if (!draftId) {
+    return redirect("/builder");
+  }
+
+  const draft = await service.getDraft(draftId);
   if (!draft) {
-    // create new draft
-    draft = createDraftSpec({ title: "Untitled Agent" });
+    // If invalid id, start a new draft
+    return redirect("/builder");
   }
 
   return json({ draft });

--- a/apps/web/app/routes/builder._index.ts
+++ b/apps/web/app/routes/builder._index.ts
@@ -1,0 +1,22 @@
+import { redirect, type LoaderFunctionArgs } from "@remix-run/node";
+import { createSpecDraftService } from "../utils/specDraft.server";
+
+function getUserId() { return "01ARZ3NDEKTSV4RRFFQ69G5FAV"; }
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = getUserId();
+  const service = createSpecDraftService(userId);
+
+  const created = await service.saveDraft({
+    title: "Untitled Agent",
+    payload: {},
+    isDraft: true,
+    status: "DRAFT",
+  });
+
+  return redirect(`/builder/${created.id}`);
+}
+
+export default function BuilderIndexRedirect() {
+  return null;
+}

--- a/packages/queue/tests/queue.integration.mjs
+++ b/packages/queue/tests/queue.integration.mjs
@@ -4,7 +4,7 @@ import Redis from 'ioredis';
 import { agentExecQueue, enqueueAgentExec, createAgentExecWorker, redisOptions } from '../dist/index.js';
 
 async function redisAvailable() {
-  const client = new Redis(redisOptions);
+  const client = new Redis({ ...redisOptions, connectTimeout: 500, retryStrategy: () => null });
   try {
     const res = await client.ping();
     return res === 'PONG';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@metaagent/interview':
         specifier: workspace:*
         version: link:../../packages/interview
+      '@metaagent/queue':
+        specifier: workspace:*
+        version: link:../../packages/queue
       '@metaagent/spec':
         specifier: workspace:*
         version: link:../../packages/spec
@@ -249,6 +252,9 @@ importers:
 
   services/builder:
     dependencies:
+      '@metaagent/db':
+        specifier: workspace:*
+        version: link:../../packages/db
       '@metaagent/queue':
         specifier: workspace:*
         version: link:../../packages/queue
@@ -258,16 +264,25 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
+      drizzle-orm:
+        specifier: ^0.32.0
+        version: 0.32.2(@types/pg@8.15.5)(pg@8.16.3)(react@18.3.1)
       fastify:
         specifier: ^4.28.1
         version: 4.29.1
     devDependencies:
+      '@types/node':
+        specifier: ^20.14.10
+        version: 20.19.13
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@24.3.1)(typescript@5.9.2)
+        version: 10.9.2(@types/node@20.19.13)(typescript@5.9.2)
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
+      vitest:
+        specifier: ^2.0.5
+        version: 2.1.9(@types/node@20.19.13)
 
   services/runner:
     dependencies:
@@ -6768,6 +6783,37 @@ packages:
 
   /trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+    dev: true
+
+  /ts-node@10.9.2(@types/node@20.19.13)(typescript@5.9.2):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.19.13
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
     dev: true
 
   /ts-node@10.9.2(@types/node@24.3.1)(typescript@5.9.2):

--- a/services/builder/package.json
+++ b/services/builder/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -p .",
     "start": "node --env-file ../../.env dist/index.js",
     "lint": "echo \"[lint] @metaagent/builder – implement later\"",
-    "test": "echo \"[test] @metaagent/builder – implement later\""
+    "test": "vitest run"
   },
   "dependencies": {
     "@metaagent/toolkit": "workspace:*",
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^2.0.5",
+    "@types/node": "^20.14.10"
   }
 }

--- a/services/builder/src/handlers/draftAutosave.ts
+++ b/services/builder/src/handlers/draftAutosave.ts
@@ -1,0 +1,46 @@
+import { db, specDrafts, setAppUser } from "@metaagent/db";
+import { and, eq } from "drizzle-orm";
+import type { DraftAutosaveData, DraftAutosaveResult } from "@metaagent/queue";
+
+export async function handleDraftAutosave({ userId, draft }: DraftAutosaveData): Promise<DraftAutosaveResult> {
+  await setAppUser(userId);
+  const now = new Date();
+
+  if (draft.id) {
+    const updated = await db
+      .update(specDrafts)
+      .set({
+        title: draft.title,
+        name: draft.title,
+        spec: draft.payload,
+        templateId: draft.templateId ?? null,
+        isDraft: draft.isDraft ?? true,
+        status: draft.status ?? 'DRAFT',
+        updatedAt: now,
+      })
+      .where(and(eq(specDrafts.id, draft.id), eq(specDrafts.ownerUserId, userId)))
+      .returning();
+
+    if (updated.length > 0) {
+      return { id: updated[0].id, updatedAt: updated[0].updatedAt?.toISOString() ?? now.toISOString() };
+    }
+  }
+
+  const created = await db
+    .insert(specDrafts)
+    .values({
+      ownerUserId: userId,
+      title: draft.title,
+      name: draft.title,
+      spec: draft.payload,
+      templateId: draft.templateId ?? null,
+      isDraft: draft.isDraft ?? true,
+      status: draft.status ?? 'DRAFT',
+      tags: [],
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return { id: created[0].id, updatedAt: created[0].updatedAt?.toISOString() ?? now.toISOString() };
+}

--- a/services/builder/src/index.ts
+++ b/services/builder/src/index.ts
@@ -2,8 +2,7 @@ import Fastify from "fastify";
 import dotenv from "dotenv";
 import { logger } from "@metaagent/toolkit";
 import { enqueueAgentExec, createDraftAutosaveWorker } from "@metaagent/queue";
-import { db, specDrafts, setAppUser } from "@metaagent/db";
-import { eq, and } from "drizzle-orm";
+import { handleDraftAutosave } from "./handlers/draftAutosave.js";
 
 dotenv.config();
 
@@ -19,48 +18,7 @@ app.post("/jobs/demo", async () => {
 });
 
 // Start Draft Autosave Worker
-createDraftAutosaveWorker(async ({ userId, draft }) => {
-  await setAppUser(userId);
-  const now = new Date();
-
-  if (draft.id) {
-    const updated = await db
-      .update(specDrafts)
-      .set({
-        title: draft.title,
-        name: draft.title,
-        spec: draft.payload,
-        templateId: draft.templateId ?? null,
-        isDraft: draft.isDraft ?? true,
-        status: draft.status ?? 'DRAFT',
-        updatedAt: now,
-      })
-      .where(and(eq(specDrafts.id, draft.id), eq(specDrafts.ownerUserId, userId)))
-      .returning();
-
-    if (updated.length > 0) {
-      return { id: updated[0].id, updatedAt: updated[0].updatedAt?.toISOString() ?? now.toISOString() };
-    }
-  }
-
-  const created = await db
-    .insert(specDrafts)
-    .values({
-      ownerUserId: userId,
-      title: draft.title,
-      name: draft.title,
-      spec: draft.payload,
-      templateId: draft.templateId ?? null,
-      isDraft: draft.isDraft ?? true,
-      status: draft.status ?? 'DRAFT',
-      tags: [],
-      createdAt: now,
-      updatedAt: now,
-    })
-    .returning();
-
-  return { id: created[0].id, updatedAt: created[0].updatedAt?.toISOString() ?? now.toISOString() };
-});
+createDraftAutosaveWorker(handleDraftAutosave);
 
 const port = Number(process.env.BUILDER_PORT ?? 3101);
 app.listen({ port, host: "0.0.0.0" }).catch((err) => {

--- a/services/builder/test/handlers.draftAutosave.test.ts
+++ b/services/builder/test/handlers.draftAutosave.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@metaagent/db', () => {
+  const rows: any[] = [];
+  const specDrafts = {} as any;
+
+  const db = {
+    update: () => ({
+      set: (_values: any) => ({
+        where: (_expr: any) => ({
+          returning: () => ([] as any[])
+        })
+      })
+    }),
+    insert: () => ({
+      values: (v: any) => ({
+        returning: () => {
+          const id = `db-${rows.length + 1}`;
+          const rec = { id, ...v };
+          rows.push(rec);
+          return [rec];
+        }
+      })
+    }),
+  } as any;
+
+  const setAppUser = async (_id: string) => {};
+
+  return { db, specDrafts, setAppUser };
+});
+
+import { handleDraftAutosave } from '../src/handlers/draftAutosave';
+
+describe('handleDraftAutosave', () => {
+  it('inserts new draft when no id provided', async () => {
+    const res = await handleDraftAutosave({ userId: 'u1', draft: { title: 'T', payload: { a: 1 } } } as any);
+    expect(res.id).toBeDefined();
+    expect(typeof res.updatedAt).toBe('string');
+  });
+});


### PR DESCRIPTION
…ve uses DB id only. Add Builder index route. Refactor autosave worker handler and add unit test. Make queue integration test skip fast when Redis unavailable. Add vitest to builder.

Amp-Thread-ID: https://ampcode.com/threads/T-9751d4d5-c658-4850-a034-4e7b88a26571